### PR TITLE
Locking processes in order to prevent errors in reading

### DIFF
--- a/custom_components/zte_router/__init__.py
+++ b/custom_components/zte_router/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import yaml
 import os
+from asyncio import Lock
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
@@ -32,10 +33,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Initialize coordinators with username if applicable
     allow_stale_data = config.get(CONF_ALLOW_STALE_DATA, DEFAULT_ALLOW_STALE_DATA)
+    lock = Lock()
     coordinator = ZTERouterDataUpdateCoordinator(
-        hass, config["router_ip"], config["router_password"], username, ping_interval, allow_stale_data
+        hass, config["router_ip"], config["router_password"], username, ping_interval, allow_stale_data, lock=lock
     )
-    sms_coordinator = ZTERouterSMSUpdateCoordinator(hass, config["router_ip"], config["router_password"], username, sms_check_interval)
+    sms_coordinator = ZTERouterSMSUpdateCoordinator(
+        hass, config["router_ip"], config["router_password"], username, sms_check_interval, lock=lock
+    )
 
     await coordinator.async_config_entry_first_refresh()
     await sms_coordinator.async_config_entry_first_refresh()


### PR DESCRIPTION
I have seen error in readings when variable and SMS readouts happened at the same time. The lock should prevent that.

<img width="1186" height="405" alt="image" src="https://github.com/user-attachments/assets/8056fab5-316b-49e8-930d-17e9c02fce39" />
