### PR TITLE
Add device tracker support and fix connected client detection for MC888A

### DIFF
--- a/custom_components/zte_router/__init__.py
+++ b/custom_components/zte_router/__init__.py
@@ -82,7 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     firmware_version = coordinator.data.get("wa_inner_version", "Unknown")
 
     # Forward entry setup to relevant platforms, including button
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "switch", "button"])
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "switch", "button", "device_tracker"])
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
@@ -242,6 +242,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     await hass.config_entries.async_forward_entry_unload(entry, "sensor")
     await hass.config_entries.async_forward_entry_unload(entry, "switch")
     await hass.config_entries.async_forward_entry_unload(entry, "button")
+    await hass.config_entries.async_forward_entry_unload(entry, "device_tracker")
     hass.data[DOMAIN].pop(entry.entry_id)
     return True
 

--- a/custom_components/zte_router/__init__.py
+++ b/custom_components/zte_router/__init__.py
@@ -16,6 +16,8 @@ from .const import (
     CONF_ALLOW_STALE_DATA,
     DEFAULT_ALLOW_STALE_DATA,
     ROUTER_TYPE_MC801,
+    ROUTER_TYPE_MC888,
+    ROUTER_TYPE_MC889,
     ROUTER_TYPE_G5_ULTRA,
 )
 from .g5_ultra_client import G5UltraRouterRunner
@@ -46,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     ping_interval = entry.options.get("ping_interval", 60)
     sms_check_interval = entry.options.get("sms_check_interval", 100)
     router_type = config.get("router_type", ROUTER_TYPE_MC801)
-    username = config.get("router_username") if router_type in ["MC888A", "MC889A"] else None
+    username = config.get("router_username") if router_type in [ROUTER_TYPE_MC888, ROUTER_TYPE_MC889] else None
 
     phone_number = config.get("phone_number", "13909")
     sms_message = config.get("sms_message", "BRZINA")

--- a/custom_components/zte_router/device_tracker.py
+++ b/custom_components/zte_router/device_tracker.py
@@ -98,6 +98,8 @@ def _device_connection_type(dev: dict) -> str:
 
 def _all_devices(data: dict) -> list[dict]:
     """Merge known client lists and de-duplicate by MAC."""
+    if not data:
+        return []
     seen: set[str] = set()
     devices: list[dict] = []
     for key in ("all_devices", "station_list", "lan_station_list"):

--- a/custom_components/zte_router/device_tracker.py
+++ b/custom_components/zte_router/device_tracker.py
@@ -1,0 +1,184 @@
+"""Device tracker platform for ZTE Router.
+
+Each device (WiFi or wired) seen by the router gets a tracked entity.
+State is 'home' when the device is in the current poll's client list,
+'not_home' when absent.
+"""
+import logging
+
+from homeassistant.components.device_tracker import SourceType
+from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER, MODEL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ZTE Router device trackers from a config entry."""
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+    coordinator = coordinators["coordinator"]
+
+    # Track which MAC addresses already have an entity so we don't duplicate.
+    tracked_macs: set[str] = set()
+
+    @callback
+    def _async_discover_devices() -> None:
+        """Create tracker entities for any newly seen devices."""
+        new_entities = []
+        for device in _all_devices(coordinator.data):
+            mac = _device_mac(device)
+            if not mac or mac in tracked_macs:
+                continue
+            tracked_macs.add(mac)
+            new_entities.append(ZTEDeviceTracker(coordinator, mac, device))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    # Initial discovery on setup.
+    _async_discover_devices()
+
+    # Re-run discovery on every coordinator update to pick up new devices.
+    entry.async_on_unload(coordinator.async_add_listener(_async_discover_devices))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_mac(mac: str) -> str:
+    """Return a lower-case, colon-separated MAC address, or '' if invalid."""
+    mac = mac.strip().lower().replace("-", ":").replace(".", ":")
+    if len(mac.split(":")) == 6:
+        return mac
+    return ""
+
+
+def _extract_first(dev: dict, keys: tuple[str, ...], default: str = "") -> str:
+    """Return the first non-empty string value from candidate keys."""
+    for key in keys:
+        value = dev.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return default
+
+
+def _device_mac(dev: dict) -> str:
+    """Extract MAC from known variants in router payloads."""
+    return _normalize_mac(
+        _extract_first(dev, ("mac_addr", "mac", "mac_address", "macAddress"))
+    )
+
+
+def _device_hostname(dev: dict) -> str:
+    """Extract hostname from known variants in router payloads."""
+    return _extract_first(dev, ("hostname", "host_name", "name", "device_name"))
+
+
+def _device_ip(dev: dict) -> str:
+    """Extract IPv4 from known variants in router payloads."""
+    return _extract_first(dev, ("ip_addr", "ip", "ip_address", "ipv4", "addr"))
+
+
+def _device_connection_type(dev: dict) -> str:
+    """Extract connection type from known variants in router payloads."""
+    return _extract_first(dev, ("type", "access_type", "connect_type", "medium"))
+
+
+def _all_devices(data: dict) -> list[dict]:
+    """Merge known client lists and de-duplicate by MAC."""
+    seen: set[str] = set()
+    devices: list[dict] = []
+    for key in ("all_devices", "station_list", "lan_station_list"):
+        for dev in data.get(key) or []:
+            mac = _device_mac(dev)
+            if mac and mac not in seen:
+                seen.add(mac)
+                devices.append(dev)
+    return devices
+
+
+def _find_device(data: dict, mac: str) -> dict | None:
+    """Return the raw device dict for *mac* from current coordinator data."""
+    for dev in _all_devices(data):
+        if _device_mac(dev) == mac:
+            return dev
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entity
+# ---------------------------------------------------------------------------
+
+class ZTEDeviceTracker(CoordinatorEntity, ScannerEntity):
+    """A single network device tracked via the ZTE Router."""
+
+    def __init__(self, coordinator, mac: str, initial_data: dict) -> None:
+        super().__init__(coordinator)
+        self._mac = mac
+        # Use hostname as display name; fall back to MAC if blank.
+        self._initial_hostname = _device_hostname(initial_data) or mac
+        self._attr_unique_id = (
+            f"{DOMAIN}_{coordinator.ip_entry}_tracker_{mac.replace(':', '')}"
+        )
+
+    @property
+    def source_type(self) -> SourceType:
+        return SourceType.ROUTER
+
+    @property
+    def is_connected(self) -> bool:
+        return _find_device(self.coordinator.data, self._mac) is not None
+
+    @property
+    def name(self) -> str:
+        dev = _find_device(self.coordinator.data, self._mac)
+        if dev:
+            return _device_hostname(dev) or self._initial_hostname
+        return self._initial_hostname
+
+    @property
+    def ip_address(self) -> str | None:
+        dev = _find_device(self.coordinator.data, self._mac)
+        return _device_ip(dev) if dev else None
+
+    @property
+    def mac_address(self) -> str:
+        return self._mac
+
+    @property
+    def hostname(self) -> str | None:
+        dev = _find_device(self.coordinator.data, self._mac)
+        return _device_hostname(dev) if dev else self._initial_hostname
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        dev = _find_device(self.coordinator.data, self._mac)
+        if not dev:
+            return {}
+        return {
+            "connection_type": _device_connection_type(dev),
+            "speed_mbps": dev.get("agreed_rate") or dev.get("speed"),
+            "connect_time_seconds": dev.get("connect_time") or dev.get("online_time"),
+            "addr_type": dev.get("addr_type") or dev.get("address_type"),
+        }
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, f"{DOMAIN}_{self.coordinator.ip_entry}")},
+            "name": self.coordinator.ip_entry,
+            "manufacturer": MANUFACTURER,
+            "model": MODEL,
+        }

--- a/custom_components/zte_router/g5_ultra_client.py
+++ b/custom_components/zte_router/g5_ultra_client.py
@@ -422,7 +422,18 @@ class G5UltraRouterRunner:
     def collect_wireless_clients(self, token: str, counts: Dict[str, Any]) -> List[Dict[str, Any]]:
         total = int(counts.get("wireless_num", 0) or 0)
         if total <= 0:
-            return []
+            # Some firmware revisions report wrong counters; probe one page anyway.
+            resp = self._ubus_call(
+                "zwrt_router.api",
+                "router_wireless_access_list",
+                {"start_id": 1, "end_id": 64},
+                token,
+            )
+            data = self._safe_result(resp)
+            info = data.get("wireless_access_list_info") if isinstance(data, dict) else None
+            records = info if isinstance(info, list) else []
+            LOGGER.debug("Collected %s wireless clients via fallback", len(records))
+            return records
         page_size = 64
         start = 1
         records: List[Dict[str, Any]] = []

--- a/custom_components/zte_router/manifest.json
+++ b/custom_components/zte_router/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues",
   "requirements": ["aiohttp"],
-  "version": "1.0.51b1"
+  "version": "1.0.53"
 }

--- a/custom_components/zte_router/mc.py
+++ b/custom_components/zte_router/mc.py
@@ -633,6 +633,35 @@ class zteRouter:
 
             combined_data = {}
 
+            def normalize_client_list(raw_value):
+                """Normalize firmware-specific list payloads to list[dict]."""
+                if isinstance(raw_value, list):
+                    return [item for item in raw_value if isinstance(item, dict)]
+
+                if isinstance(raw_value, str):
+                    text = raw_value.strip()
+                    if not text or text.lower() in ("null", "none", "[]"):
+                        return []
+                    try:
+                        decoded = json.loads(text)
+                        if isinstance(decoded, list):
+                            return [item for item in decoded if isinstance(item, dict)]
+                        if isinstance(decoded, dict):
+                            for nested_key in ("list", "items", "devices", "clients"):
+                                nested = decoded.get(nested_key)
+                                if isinstance(nested, list):
+                                    return [item for item in nested if isinstance(item, dict)]
+                    except Exception:
+                        return []
+
+                if isinstance(raw_value, dict):
+                    for nested_key in ("list", "items", "devices", "clients"):
+                        nested = raw_value.get(nested_key)
+                        if isinstance(nested, list):
+                            return [item for item in nested if isinstance(item, dict)]
+
+                return []
+
             for param in ["station_list", "lan_station_list"]:
                 cmd_str = quote(param)
                 url = f"{self.protocol}://{self.ip}/goform/goform_get_cmd_process?isTest=false&cmd={cmd_str}"
@@ -644,12 +673,29 @@ class zteRouter:
                 try:
                     parsed = json.loads(raw_data)
 
+                    raw_clients = parsed.get(param, [])
+                    clients = normalize_client_list(raw_clients)
+
+                    # Firmware fallback keys
+                    if not clients:
+                        alt_candidates = [
+                            "wireless_access_list_info" if param == "station_list" else "lan_access_list_info",
+                            "clients",
+                            "devices",
+                            "list",
+                            "items",
+                        ]
+                        for alt_key in alt_candidates:
+                            clients = normalize_client_list(parsed.get(alt_key, []))
+                            if clients:
+                                break
+
                     # Tag each device with type: WiFi or LAN
-                    for item in parsed.get(param, []):
+                    for item in clients:
                         item["type"] = "WiFi" if param == "station_list" else "LAN"
 
-                    combined_data[param] = parsed.get(param, [])
-                    logger.debug(f"Fetched {param} with {len(parsed.get(param, []))} entries")
+                    combined_data[param] = clients
+                    logger.debug(f"Fetched {param} with {len(clients)} entries")
                 except Exception as ex:
                     logger.warning(f"Failed to parse {param}: {ex}")
                     combined_data[param] = []

--- a/custom_components/zte_router/sensor.py
+++ b/custom_components/zte_router/sensor.py
@@ -1122,7 +1122,7 @@ class ConnectedDevicesSensor(ZTERouterEntity):
 
     @property
     def state(self):
-        return len(self._attributes.get("station_list", []))
+        return self._state
 
     @property
     def unique_id(self):
@@ -1158,8 +1158,24 @@ class ConnectedDevicesSensor(ZTERouterEntity):
     async def async_handle_coordinator_update(self):
         if self.coordinator.data:
             station_list = self.coordinator.data.get("station_list", [])
+            lan_station_list = self.coordinator.data.get("lan_station_list", [])
+            all_devices = self.coordinator.data.get("all_devices")
+
+            if isinstance(all_devices, list) and all_devices:
+                total_devices = len(all_devices)
+            else:
+                total_devices = len(station_list) + len(lan_station_list)
+                if total_devices == 0:
+                    try:
+                        total_devices = int(str(self.coordinator.data.get("wifi_access_sta_num", "0")).strip())
+                    except Exception:
+                        total_devices = 0
+
+            self._state = total_devices
             self._attributes["station_list"] = station_list
-            _LOGGER.info(f"Connected Devices updated: {len(station_list)} devices")
+            self._attributes["lan_station_list"] = lan_station_list
+            self._attributes["all_devices"] = all_devices if isinstance(all_devices, list) else (station_list + lan_station_list)
+            _LOGGER.info(f"Connected Devices updated: {total_devices} devices")
         else:
             _LOGGER.warning("No data available for Connected Devices")
         self.async_write_ha_state()
@@ -1180,7 +1196,7 @@ class WiFiClientsSensor(ZTERouterEntity):
 
     @property
     def state(self):
-        return len(self._attributes.get("wifi_clients", []))
+        return self._state
 
     @property
     def unique_id(self):
@@ -1214,28 +1230,44 @@ class WiFiClientsSensor(ZTERouterEntity):
 
     @guard_stale_data
     async def async_handle_coordinator_update(self):
-        wifi_clients = self.coordinator.data.get("station_list") if self.coordinator.data else None
+        data = self.coordinator.data if self.coordinator.data else {}
+        wifi_clients = data.get("station_list") or []
 
-        if wifi_clients is not None:
-            self._state = len(wifi_clients)
-            formatted_clients = []
-            for client in wifi_clients:
-                formatted_clients.append({
-                    "Hostname": client.get("hostname", "--"),
-                    "MAC Address": client.get("mac_addr", "--"),
-                    "IP Address": client.get("ip_addr", "--"),
-                    "Speed": f"{client.get('agreed_rate', '--')} Mbps",
-                    "Connected": format_seconds(client.get("connect_time", 0)),
-                    "Address Type": client.get("addr_type", "--"),
-                    "Type": client.get("type", "--"),
-                })
+        formatted_clients = []
+        for client in wifi_clients:
+            formatted_clients.append({
+                "Hostname": client.get("hostname", "--"),
+                "MAC Address": client.get("mac_addr", client.get("mac", "--")),
+                "IP Address": client.get("ip_addr", client.get("ip", "--")),
+                "Speed": f"{client.get('agreed_rate', client.get('speed', '--'))} Mbps",
+                "Connected": format_seconds(client.get("connect_time", client.get("online_time", 0))),
+                "Address Type": client.get("addr_type", client.get("address_type", "--")),
+                "Type": client.get("type", "WiFi"),
+            })
+
+        # Firmware BD_A1EUMC888AV1.0.0B06 may not expose station_list reliably.
+        if formatted_clients:
+            self._state = len(formatted_clients)
             self._attributes["wifi_clients"] = formatted_clients
-            _LOGGER.info(f"WiFi Clients sensor updated: {self._state} devices")
         else:
-            _LOGGER.warning("WiFi Clients sensor: No data available or update failed. Setting state to unavailable.")
-            self._state = None
-            self._attributes.clear()
+            def _as_int(value):
+                try:
+                    return int(str(value).strip())
+                except Exception:
+                    return 0
 
+            fallback_count = max(
+                _as_int(data.get("wifi_access_sta_num")),
+                _as_int(data.get("wifi_chip1_ssid1_access_sta_num")) +
+                _as_int(data.get("wifi_chip2_ssid1_access_sta_num")) +
+                _as_int(data.get("wifi_chip1_ssid2_access_sta_num")) +
+                _as_int(data.get("wifi_chip2_ssid2_access_sta_num")),
+            )
+            self._state = fallback_count
+            self._attributes["wifi_clients"] = []
+            self._attributes["fallback_count_source"] = "wifi_access_sta_num"
+
+        _LOGGER.info(f"WiFi Clients sensor updated: {self._state} devices")
         self.async_write_ha_state()
 
 
@@ -1255,7 +1287,7 @@ class LANClientsSensor(ZTERouterEntity):
 
     @property
     def state(self):
-        return len(self._attributes.get("lan_clients", []))
+        return self._state
 
     @property
     def available(self):
@@ -1289,28 +1321,24 @@ class LANClientsSensor(ZTERouterEntity):
 
     @guard_stale_data
     async def async_handle_coordinator_update(self):
-        lan_clients = self.coordinator.data.get("lan_station_list") if self.coordinator.data else None
+        data = self.coordinator.data if self.coordinator.data else {}
+        lan_clients = data.get("lan_station_list") or []
 
-        if lan_clients is not None:
-            self._state = len(lan_clients)
-            formatted_clients = []
-            for client in lan_clients:
-                formatted_clients.append({
-                    "Hostname": client.get("hostname", "--"),
-                    "MAC Address": client.get("mac_addr", "--"),
-                    "IP Address": client.get("ip_addr", "--"),
-                    "Speed": f"{client.get('agreed_rate', '--')} Mbps",
-                    "Connected": format_seconds(client.get("connect_time", 0)),
-                    "Address Type": client.get("addr_type", "--"),
-                    "Type": client.get("type", "--"),
-                })
-            self._attributes["lan_clients"] = formatted_clients
-            _LOGGER.info(f"LAN Clients sensor updated: {self._state} devices")
-        else:
-            _LOGGER.warning("LAN Clients sensor: No data available or update failed. Setting state to unavailable.")
-            self._state = None
-            self._attributes.clear()
+        formatted_clients = []
+        for client in lan_clients:
+            formatted_clients.append({
+                "Hostname": client.get("hostname", "--"),
+                "MAC Address": client.get("mac_addr", client.get("mac", "--")),
+                "IP Address": client.get("ip_addr", client.get("ip", "--")),
+                "Speed": f"{client.get('agreed_rate', client.get('speed', '--'))} Mbps",
+                "Connected": format_seconds(client.get("connect_time", client.get("online_time", 0))),
+                "Address Type": client.get("addr_type", client.get("address_type", "--")),
+                "Type": client.get("type", "LAN"),
+            })
 
+        self._state = len(formatted_clients)
+        self._attributes["lan_clients"] = formatted_clients
+        _LOGGER.info(f"LAN Clients sensor updated: {self._state} devices")
         self.async_write_ha_state()
 
 


### PR DESCRIPTION
This PR adds `device_tracker` support and fixes client detection logic that could keep connected-device entities at `0` and prevent tracker creation.

### Key changes

- Added new `device_tracker` platform:
  - one tracker per MAC address
  - presence based on current router client lists
- Registered/unregistered `device_tracker` in config entry setup/unload
- Fixed client sensor state handling (`Connected Devices`, `WiFi Clients`, `LAN Clients`) to use computed internal state correctly
- Improved client payload normalization in `zteinfo4()` for firmware response variations
- Added multi-key extraction fallbacks for MAC/hostname/IP fields
- Fixed MC888/MC889 username login routing (router type check used wrong string variants), which could cause authenticated client endpoints to return empty lists
- Added defensive guard for empty coordinator data in device discovery path

### Validation

- Tested on **MC888A** firmware **BD_A1EUMC888AV1.0.0B06**
- Confirmed correct WiFi/LAN/total client counts and `device_tracker.*` creation/update

### Scope / caveat

- **Tested only on MC888A**
- Behavior on other models/firmware is not guaranteed yet and needs broader field validation