### PR TITLE
Fix mc.py path resolution for non-/config Home Assistant installs

### DIFF
--- a/custom_components/zte_router/manifest.json
+++ b/custom_components/zte_router/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues",
   "requirements": ["aiohttp"],
-  "version": "1.0.54"
+  "version": "1.0.55"
 }

--- a/custom_components/zte_router/router_backend.py
+++ b/custom_components/zte_router/router_backend.py
@@ -1,12 +1,13 @@
 import logging
 import subprocess
+from pathlib import Path
 from typing import Optional
 
 from .const import ROUTER_TYPE_G5_ULTRA
 from .g5_ultra_client import G5UltraRouterRunner
 
 LOGGER = logging.getLogger(__name__)
-MC_SCRIPT_PATH = "/config/custom_components/zte_router/mc.py"
+MC_SCRIPT_PATH = str(Path(__file__).resolve().with_name("mc.py"))
 
 
 def run_router_commands(


### PR DESCRIPTION
This PR removes the hardcoded /config/custom_components/zte_router/mc.py assumption and resolves mc.py relative to the integration module path.

Why
Home Assistant custom integrations can live under different config roots (for example ~/.homeassistant, so hardcoding /config breaks valid installations.

Impact

Fixes command execution in non-/config setups
Keeps behavior working in /config-based installs
No user configuration changes required