### PR TITLE
Add WiFi on/off switch for MC-series routers

### DIFF
--- a/custom_components/zte_router/mc.py
+++ b/custom_components/zte_router/mc.py
@@ -1139,6 +1139,33 @@ class zteRouter:
             logger.error(f"Failed to set data mode '{BearerPreference}': {e}")
             return None
 
+    def wifi_switch(self, enable: bool):
+        """Enable or disable all WiFi radios on the router.
+
+        Uses goformId=switchWiFiModule with SwitchOption=1 (on) or 0 (off).
+        This goformId was identified by intercepting the network requests made
+        by the router's own web UI (confirmed on MC888 Ultra firmware
+        CR_VDFEUMC888ULTRAV1.0.0B10).
+        """
+        state = "1" if enable else "0"
+        logger.debug(f"Setting WiFi {'on' if enable else 'off'}")
+        try:
+            AD = getattr(self, "_zte_auth_AD", None)
+            header = {"Referer": self.referer}
+            payload = {
+                'goformId': 'switchWiFiModule',
+                'isTest': 'false',
+                'SwitchOption': state,
+                'AD': AD
+            }
+            encoded_payload = urllib.parse.urlencode(payload)
+            body = encoded_payload.encode('utf-8')
+            r = self.request_with_session('POST', self.referer + "goform/goform_set_cmd_process", headers=header, body=body)
+            logger.info(f"WiFi switch {'on' if enable else 'off'} with status code: {r.status}")
+            return r.status
+        except Exception as e:
+            logger.error(f"Failed to switch WiFi {'on' if enable else 'off'}: {e}")
+            return None
 
 
 # Global variables for SMS sending
@@ -1255,6 +1282,10 @@ if __name__ == "__main__":
                 results[cmd_id] = zte.setdata_mode("WL_AND_5G")
             elif cmd_id == 16:
                 results[cmd_id] = json.loads(zte.zteinfo4())
+            elif cmd_id == 17:
+                results[cmd_id] = zte.wifi_switch(True)
+            elif cmd_id == 18:
+                results[cmd_id] = zte.wifi_switch(False)
             else:
                 results[cmd_id] = f"Invalid command: {cmd_id}"
         except Exception as e:

--- a/custom_components/zte_router/switch.py
+++ b/custom_components/zte_router/switch.py
@@ -1,48 +1,88 @@
+import asyncio
 import logging
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN, MANUFACTURER, MODEL
+from .const import (
+    DOMAIN,
+    MANUFACTURER,
+    MODEL,
+    ROUTER_TYPE_G5_ULTRA,
+    ROUTER_TYPE_MC801,
+    ROUTER_TYPE_MC888,
+    ROUTER_TYPE_MC889,
+)
+from .router_backend import run_router_commands
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the dummy switch platform."""
+    """Set up the switch platform."""
     coordinators = hass.data[DOMAIN][config_entry.entry_id]
     main_coordinator = coordinators["coordinator"]
     ip_entry = config_entry.data["router_ip"]
+    password_entry = config_entry.data["router_password"]
+    router_type = config_entry.data.get("router_type", ROUTER_TYPE_MC801)
 
-    # Comment out or remove the dummy switch creation for now
-    # async_add_entities([
-    #     DummySwitch(main_coordinator, ip_entry, "Dummy Switch")
-    # ], False)
+    # Handle username (only required for certain router models)
+    username_entry = (
+        config_entry.data.get("router_username")
+        if config_entry.data.get("router_type") in [ROUTER_TYPE_MC888, ROUTER_TYPE_MC889]
+        else None
+    )
 
-class DummySwitch(CoordinatorEntity, SwitchEntity):
-    """Representation of a dummy switch."""
+    # WiFi switch is only supported on MC-series routers.
+    # G5 Ultra uses a different (ubus) API; its WiFi toggle is not yet implemented.
+    if router_type != ROUTER_TYPE_G5_ULTRA:
+        async_add_entities([
+            WiFiSwitch(main_coordinator, ip_entry, password_entry, username_entry, router_type)
+        ], False)
 
-    def __init__(self, coordinator, ip_entry, name):
-        """Initialize the switch."""
+
+class WiFiSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch entity to enable or disable the router's WiFi radios.
+
+    Confirmed working on: ZTE MC888 Ultra (firmware CR_VDFEUMC888ULTRAV1.0.0B10).
+    Expected to work on all MC-series routers (MC801, MC888, MC889) that share
+    the same goform HTTP API.
+
+    State is read from the 'wifi_onoff_state' field returned by the coordinator.
+    The toggle uses goformId=switchWiFiModule with SwitchOption=1 (on) / 0 (off),
+    discovered by intercepting network requests from the router's own web UI.
+    """
+
+    def __init__(self, coordinator, ip_entry, password_entry, username_entry, router_type):
+        """Initialize the WiFi switch."""
         super().__init__(coordinator)
         self._ip = ip_entry
-        self._name = name
-        self._state = False
+        self._password = password_entry
+        self._username = username_entry if username_entry else ""
+        self._router_type = router_type
 
     @property
     def name(self):
         """Return the name of the switch."""
-        return self._name
-
-    @property
-    def is_on(self):
-        """Return the state of the switch."""
-        return self._state
+        return "Router WiFi"
 
     @property
     def unique_id(self):
-        return f"{DOMAIN}_{self._ip}_dummy_switch"
+        """Return a unique ID for this switch."""
+        return f"{DOMAIN}_{self._ip}_wifi_switch"
+
+    @property
+    def icon(self):
+        """Return an icon reflecting the current WiFi state."""
+        return "mdi:wifi" if self.is_on else "mdi:wifi-off"
+
+    @property
+    def is_on(self):
+        """Return True if WiFi is currently enabled."""
+        data = self.coordinator.data or {}
+        return data.get("wifi_onoff_state", "0") == "1"
 
     @property
     def device_info(self):
-        """Return the device info for the switch."""
+        """Return device info to group this switch with the router device."""
         return {
             "identifiers": {(DOMAIN, f"{DOMAIN}_{self._ip}")},
             "name": self._ip,
@@ -52,11 +92,27 @@ class DummySwitch(CoordinatorEntity, SwitchEntity):
         }
 
     async def async_turn_on(self, **kwargs):
-        """Turn the switch on."""
-        self._state = True
-        self.async_write_ha_state()
+        """Enable WiFi radios."""
+        await self.hass.async_add_executor_job(self._execute_command, "17")
+        await asyncio.sleep(3)
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):
-        """Turn the switch off."""
-        self._state = False
-        self.async_write_ha_state()
+        """Disable WiFi radios."""
+        await self.hass.async_add_executor_job(self._execute_command, "18")
+        await asyncio.sleep(3)
+        await self.coordinator.async_request_refresh()
+
+    def _execute_command(self, command: str):
+        """Run a WiFi toggle command via the router backend."""
+        try:
+            result = run_router_commands(
+                self._router_type,
+                self._ip,
+                self._password,
+                self._username,
+                command,
+            )
+            _LOGGER.info("WiFi toggle command %s output: %s", command, result)
+        except Exception as err:
+            _LOGGER.error("WiFi toggle command %s failed: %s", command, err)


### PR DESCRIPTION
Ports PR #57 from frischeDaten (feat/wifi-switch), replacing the placeholder DummySwitch with a functional WiFiSwitch entity backed by goformId=switchWiFiModule, identified by intercepting the router web UI's own requests. Confirmed working on MC888 Ultra firmware CR_VDFEUMC888ULTRAV1.0.0B10.

Fixes a bug in the original PR: it gated router_username on the literal strings "MC888A"/"MC889A", which never match the actual ROUTER_TYPE_MC888/ROUTER_TYPE_MC889 constant values ("MC888"/"MC889"), so the switch would always authenticate without a username on models that require one. Now uses the same constants as __init__.py.