### PR TITLE
Add send_custom_sms service for arbitrary phone/message SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,34 @@ To install beta versions from HACS:
 
 ![SCreenshot](https://raw.githubusercontent.com/Kajkac/ZTE-MC-Home-assistant-repo/main/zte.png)
 
+## 📡 Services
+
+### `zte_router.send_custom_sms`
+
+Send an SMS with any phone number and message, independent of the phone numbers configured during setup. Useful for calling from your own automations/scripts.
+
+**Fields:**
+- `message` (required) — the text to send.
+- `phone_number` or `phone` (required, provide either one) — destination number.
+- `entry_id` (optional) — only needed if you have more than one ZTE Router entry configured; omit it if you only have one.
+
+Example, in an automation action or a script:
+
+```yaml
+action: zte_router.send_custom_sms
+data:
+  phone_number: "0989072702"
+  message: "Garage door left open for 10 minutes"
+```
+
+Or from Developer Tools → Actions, call `zte_router.send_custom_sms` with the same fields.
+
+This works on all supported router types (MC801, MC888, MC889, G5 Ultra) and reuses the same underlying send-SMS command as the built-in "Send SMS" buttons — it does not affect or replace your configured automations, it's just another way to trigger an SMS with content you choose at call time.
+
+### `zte_router.ubus_call`
+
+Advanced/debug service for G5 Ultra routers only — invokes an arbitrary ubus module/method directly (e.g. for exploring endpoints not yet exposed as sensors). Fields: `module`, `method`, optional `params` (JSON object) and `entry_id`. Not needed for normal use.
+
 ## 🐞 Known Issues
 
 - Some sensors may occasionally show `unknown` until refreshed

--- a/custom_components/zte_router/__init__.py
+++ b/custom_components/zte_router/__init__.py
@@ -364,7 +364,8 @@ def _ensure_services_registered(hass: HomeAssistant) -> None:
         if isinstance(result, int) and not (200 <= result < 300):
             raise HomeAssistantError(f"Router returned HTTP status {result} while sending SMS")
 
-        _LOGGER.info("send_custom_sms: sent SMS to %s via entry %s", phone, entry.entry_id)
+        masked_phone = f"{'*' * max(len(phone) - 2, 0)}{phone[-2:] if len(phone) >= 2 else phone}"
+        _LOGGER.info("send_custom_sms: sent SMS to %s via entry %s", masked_phone, entry.entry_id)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/zte_router/__init__.py
+++ b/custom_components/zte_router/__init__.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 
@@ -21,10 +22,12 @@ from .const import (
     ROUTER_TYPE_G5_ULTRA,
 )
 from .g5_ultra_client import G5UltraRouterRunner
+from .router_backend import run_router_commands
 from .sensor import ZTERouterDataUpdateCoordinator, ZTERouterSMSUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 SERVICE_UBUS_CALL = "ubus_call"
+SERVICE_SEND_CUSTOM_SMS = "send_custom_sms"
 SERVICE_REG_KEY = "__zte_router_service_registered"
 SERVICE_UBUS_CALL_SCHEMA = vol.Schema(
     {
@@ -32,6 +35,14 @@ SERVICE_UBUS_CALL_SCHEMA = vol.Schema(
         vol.Required("module"): cv.string,
         vol.Required("method"): cv.string,
         vol.Optional("params", default={}): dict,
+    }
+)
+SERVICE_SEND_CUSTOM_SMS_SCHEMA = vol.Schema(
+    {
+        vol.Optional("entry_id"): cv.string,
+        vol.Optional("phone"): cv.string,
+        vol.Optional("phone_number"): cv.string,
+        vol.Required("message"): cv.string,
     }
 )
 
@@ -253,31 +264,35 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+def _resolve_config_entry(hass: HomeAssistant, entry_id: str | None) -> ConfigEntry:
+    """Resolve the target config entry for a service call, defaulting to the only active one."""
+    active_entries = [
+        eid for eid in hass.data[DOMAIN]
+        if isinstance(hass.data[DOMAIN].get(eid), dict)
+    ]
+    if not entry_id:
+        if len(active_entries) == 1:
+            entry_id = active_entries[0]
+        else:
+            raise HomeAssistantError(
+                "Multiple ZTE Router entries found. Specify entry_id in the service call."
+            )
+    if entry_id not in hass.data[DOMAIN]:
+        raise HomeAssistantError(f"Unknown ZTE Router entry_id: {entry_id}")
+
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None:
+        raise HomeAssistantError(f"No config entry found for id {entry_id}")
+    return entry
+
+
 def _ensure_services_registered(hass: HomeAssistant) -> None:
     storage = hass.data.setdefault(DOMAIN, {})
     if storage.get(SERVICE_REG_KEY):
         return
 
     async def async_handle_ubus_call(call: ServiceCall):
-        entry_id = call.data.get("entry_id")
-        active_entries = [
-            eid for eid in hass.data[DOMAIN]
-            if isinstance(hass.data[DOMAIN].get(eid), dict)
-        ]
-        if not entry_id:
-            if len(active_entries) == 1:
-                entry_id = active_entries[0]
-            else:
-                raise HomeAssistantError(
-                    "Multiple ZTE Router entries found. Specify entry_id in the service call."
-                )
-        if entry_id not in hass.data[DOMAIN]:
-            raise HomeAssistantError(f"Unknown ZTE Router entry_id: {entry_id}")
-
-        entry = hass.config_entries.async_get_entry(entry_id)
-        if entry is None:
-            raise HomeAssistantError(f"No config entry found for id {entry_id}")
-
+        entry = _resolve_config_entry(hass, call.data.get("entry_id"))
         merged = {**entry.data, **entry.options}
         router_type = merged.get("router_type", ROUTER_TYPE_MC801)
         if router_type != ROUTER_TYPE_G5_ULTRA:
@@ -300,7 +315,7 @@ def _ensure_services_registered(hass: HomeAssistant) -> None:
         hass.bus.async_fire(
             f"{DOMAIN}_ubus_response",
             {
-                "entry_id": entry_id,
+                "entry_id": entry.entry_id,
                 "module": module,
                 "method": method,
                 "params": params,
@@ -309,10 +324,58 @@ def _ensure_services_registered(hass: HomeAssistant) -> None:
             },
         )
 
+    async def async_handle_send_custom_sms(call: ServiceCall):
+        entry = _resolve_config_entry(hass, call.data.get("entry_id"))
+        merged = {**entry.data, **entry.options}
+        router_type = merged.get("router_type", ROUTER_TYPE_MC801)
+        username = merged.get("router_username") if router_type in [ROUTER_TYPE_MC888, ROUTER_TYPE_MC889] else None
+
+        phone = (call.data.get("phone") or call.data.get("phone_number") or "").strip()
+        if not phone:
+            raise HomeAssistantError("send_custom_sms: provide 'phone' or 'phone_number'")
+        message = call.data["message"].strip()
+        if not message:
+            raise HomeAssistantError("send_custom_sms: 'message' cannot be empty")
+
+        try:
+            raw = await hass.async_add_executor_job(
+                run_router_commands,
+                router_type,
+                merged["router_ip"],
+                merged["router_password"],
+                username,
+                "8",
+                phone,
+                message,
+            )
+        except Exception as err:
+            raise HomeAssistantError(f"Failed to send SMS: {err}") from err
+
+        try:
+            parsed = json.loads(raw)
+        except Exception as err:
+            raise HomeAssistantError(f"Unexpected response from router: {raw}") from err
+
+        result = parsed.get("8")
+        if result is None:
+            raise HomeAssistantError(f"No result returned for send SMS command: {parsed}")
+        if isinstance(result, dict) and result.get("error"):
+            raise HomeAssistantError(f"Failed to send SMS: {result['error']}")
+        if isinstance(result, int) and not (200 <= result < 300):
+            raise HomeAssistantError(f"Router returned HTTP status {result} while sending SMS")
+
+        _LOGGER.info("send_custom_sms: sent SMS to %s via entry %s", phone, entry.entry_id)
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_UBUS_CALL,
         async_handle_ubus_call,
         schema=SERVICE_UBUS_CALL_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEND_CUSTOM_SMS,
+        async_handle_send_custom_sms,
+        schema=SERVICE_SEND_CUSTOM_SMS_SCHEMA,
     )
     storage[SERVICE_REG_KEY] = True

--- a/custom_components/zte_router/__init__.py
+++ b/custom_components/zte_router/__init__.py
@@ -364,8 +364,7 @@ def _ensure_services_registered(hass: HomeAssistant) -> None:
         if isinstance(result, int) and not (200 <= result < 300):
             raise HomeAssistantError(f"Router returned HTTP status {result} while sending SMS")
 
-        masked_phone = f"{'*' * max(len(phone) - 2, 0)}{phone[-2:] if len(phone) >= 2 else phone}"
-        _LOGGER.info("send_custom_sms: sent SMS to %s via entry %s", masked_phone, entry.entry_id)
+        _LOGGER.info("send_custom_sms: sent SMS via entry %s", entry.entry_id)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/zte_router/services.yaml
+++ b/custom_components/zte_router/services.yaml
@@ -32,3 +32,36 @@
       required: false
       selector:
         object:
+
+send_custom_sms:
+  name: Send custom SMS
+  description: Send an SMS with an arbitrary phone number and message through a configured router entry, independent of the pre-configured automation phone numbers.
+  fields:
+    entry_id:
+      name: Entry ID
+      description: Specific config entry ID when multiple routers are configured.
+      example: 1234567890abcdef1234567890abcdef
+      required: false
+      selector:
+        text:
+    phone_number:
+      name: Phone number
+      description: Destination phone number.
+      example: "0989072702"
+      required: false
+      selector:
+        text:
+    phone:
+      name: Phone (alias)
+      description: Alias for phone_number. Provide either this or phone_number.
+      example: "0989072702"
+      required: false
+      selector:
+        text:
+    message:
+      name: Message
+      description: SMS message text to send.
+      example: "Hello from Home Assistant"
+      required: true
+      selector:
+        text:


### PR DESCRIPTION
Adapts the idea from PR #53 (AdamWeglarz), which added a zte_router.send_custom_sms service so automations/scripts can send an SMS to any number with any message, instead of being limited to the three phone/message pairs configured at setup.

Reworked to reuse the existing router_backend.run_router_commands() abstraction rather than reimplementing a separate mc.py subprocess call:
- Works correctly on G5 Ultra routers too (run_commands already maps command "8" to send_sms there); the original implementation always shelled out to the legacy mc.py backend regardless of router_type, which would have silently misrouted G5 Ultra calls to the wrong API.
- Registered once via the existing _ensure_services_registered() hass-wide guard, alongside ubus_call, instead of being called from three different exit points inside the automation-writing logic in async_setup_entry.
- Entry resolution (defaulting to the single active entry, or requiring entry_id when multiple exist) is now shared with ubus_call via a new _resolve_config_entry() helper instead of being duplicated.

Existing automations, buttons, and the fixed phone_number/sms_message config flow are untouched — this is purely additive, using the same underlying send-SMS command (id 8) your buttons already call.