### PR TITLE
Auto-bump manifest.json version on integration changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,21 +16,50 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-    - name: Read current version from manifest.json
-      id: read_version
+    - name: Bump version if integration files changed
+      id: prep
+      env:
+        BEFORE_SHA: ${{ github.event.before }}
       run: |
-        VERSION=$(jq -r '.version' custom_components/zte_router/manifest.json)
-        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-        echo "Current version: ${VERSION}"
+        set -e
+        MANIFEST=custom_components/zte_router/manifest.json
+        CURRENT=$(jq -r '.version' "$MANIFEST")
+        LAST_MSG=$(git log -1 --pretty=%s)
+        NEW_VERSION="$CURRENT"
+
+        if [[ "$LAST_MSG" == "chore: bump version"* ]]; then
+          echo "Last commit is itself a version bump; nothing to do."
+        elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ] && git cat-file -e "$BEFORE_SHA" 2>/dev/null && git diff --quiet "$BEFORE_SHA" HEAD -- custom_components/; then
+          echo "No integration files changed in this push; skipping version bump."
+        elif [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          jq --arg v "$NEW_VERSION" '.version = $v' "$MANIFEST" > /tmp/manifest.json
+          mv /tmp/manifest.json "$MANIFEST"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$MANIFEST"
+          git commit -m "chore: bump version to ${NEW_VERSION}"
+          git push
+          echo "Bumped version: ${CURRENT} -> ${NEW_VERSION}"
+        else
+          echo "Current version '${CURRENT}' is not a plain MAJOR.MINOR.PATCH (looks like a manual beta/rc); leaving it as-is."
+        fi
+
+        echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Check if release already exists
       id: check_release
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        if gh release view "${{ steps.read_version.outputs.version }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-          echo "Release ${{ steps.read_version.outputs.version }} already exists; skipping."
+        if gh release view "${{ steps.prep.outputs.version }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          echo "Release ${{ steps.prep.outputs.version }} already exists; skipping."
           echo "exists=true" >> "$GITHUB_OUTPUT"
         else
           echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -55,10 +84,10 @@ jobs:
       if: steps.check_release.outputs.exists == 'false'
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ steps.read_version.outputs.version }}
-        name: ZTE_MC_HA_CI_v${{ steps.read_version.outputs.version }}
+        tag_name: ${{ steps.prep.outputs.version }}
+        name: ZTE_MC_HA_CI_v${{ steps.prep.outputs.version }}
         body: |
           Changes in this release:
           - ${{ steps.last_commit.outputs.message }}
-        prerelease: ${{ contains(steps.read_version.outputs.version, 'b') || contains(steps.read_version.outputs.version, 'beta') || contains(steps.read_version.outputs.version, 'rc') || contains(steps.read_version.outputs.version, 'alpha') }}
+        prerelease: ${{ contains(steps.prep.outputs.version, 'b') || contains(steps.prep.outputs.version, 'beta') || contains(steps.prep.outputs.version, 'rc') || contains(steps.prep.outputs.version, 'alpha') }}
         files: zte_router.zip


### PR DESCRIPTION
The release workflow already creates a release from whatever version is in manifest.json, but nothing ever bumped that version automatically -- three feature merges (RED-crypto SMS, WiFi switch, custom SMS service) landed on main without a version bump, so no new release was ever cut for them despite the release pipeline itself working correctly.

Adds an auto-bump step that runs before release creation:
- Skips if no files under custom_components/ changed in the push (so doc-only or workflow-only merges don't bump the version)
- Skips if the current version has a beta/rc suffix (assume a manual beta cycle is in progress and shouldn't be auto-incremented)
- Otherwise increments the patch number, commits the bump to main, and the existing release step picks up the new version

Loop-safety: pushes made with the default GITHUB_TOKEN don't trigger new workflow runs, and the last-commit-message check is an explicit second guard against double-bumping.