### PR TITLE
Bump version to 1.0.55

### DIFF
--- a/custom_components/zte_router/manifest.json
+++ b/custom_components/zte_router/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues",
   "requirements": ["aiohttp"],
-  "version": "1.0.54"
+  "version": "1.0.55"
 }


### PR DESCRIPTION
Covers the features merged today that never got a version bump:
- RED-encryption SMS support + TLS fix (#66)
- WiFi on/off switch for MC-series routers (#67)
- send_custom_sms service (#68)
- Release pipeline fixes and auto-version-bump automation (#65, #69)