### PR TITLE
Fix auto-bump: check release existence, open a PR instead of pushing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -19,58 +20,60 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Bump version if integration files changed
+    - name: Decide release/bump action
       id: prep
       env:
-        BEFORE_SHA: ${{ github.event.before }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -e
         MANIFEST=custom_components/zte_router/manifest.json
         CURRENT=$(jq -r '.version' "$MANIFEST")
-        LAST_MSG=$(git log -1 --pretty=%s)
-        NEW_VERSION="$CURRENT"
 
-        if [[ "$LAST_MSG" == "chore: bump version"* ]]; then
-          echo "Last commit is itself a version bump; nothing to do."
-        elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ] && git cat-file -e "$BEFORE_SHA" 2>/dev/null && git diff --quiet "$BEFORE_SHA" HEAD -- custom_components/; then
-          echo "No integration files changed in this push; skipping version bump."
-        elif [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-          MAJOR="${BASH_REMATCH[1]}"
-          MINOR="${BASH_REMATCH[2]}"
-          PATCH="${BASH_REMATCH[3]}"
-          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
-          jq --arg v "$NEW_VERSION" '.version = $v' "$MANIFEST" > /tmp/manifest.json
-          mv /tmp/manifest.json "$MANIFEST"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$MANIFEST"
-          git commit -m "chore: bump version to ${NEW_VERSION}"
-          git push
-          echo "Bumped version: ${CURRENT} -> ${NEW_VERSION}"
+        if gh release view "$CURRENT" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          # This version is already released. If it's a plain MAJOR.MINOR.PATCH,
+          # open a PR bumping the patch number so the next merge gets a release.
+          # Beta/rc versions are left alone -- assume a manual beta cycle.
+          if [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            BRANCH="chore/bump-${NEW_VERSION}"
+
+            if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+              echo "Branch ${BRANCH} already exists upstream; a bump PR is presumably already open. Nothing to do."
+            else
+              git checkout -b "$BRANCH"
+              jq --arg v "$NEW_VERSION" '.version = $v' "$MANIFEST" > /tmp/manifest.json
+              mv /tmp/manifest.json "$MANIFEST"
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git add "$MANIFEST"
+              git commit -m "chore: bump version to ${NEW_VERSION}"
+              git push origin "$BRANCH"
+              gh pr create \
+                --title "chore: bump version to ${NEW_VERSION}" \
+                --body "Automated version bump: ${CURRENT} is already released, so this bumps the patch version to ${NEW_VERSION} to prepare the next release. Merge to release it." \
+                --base main \
+                --head "$BRANCH"
+              gh pr merge "$BRANCH" --auto --squash || echo "Auto-merge could not be enabled (may need 'Allow auto-merge' turned on in repo settings); merge the bump PR manually."
+            fi
+          else
+            echo "Version ${CURRENT} already released and is not a plain MAJOR.MINOR.PATCH (looks like a manual beta/rc); nothing to auto-bump."
+          fi
+          echo "should_release=false" >> "$GITHUB_OUTPUT"
         else
-          echo "Current version '${CURRENT}' is not a plain MAJOR.MINOR.PATCH (looks like a manual beta/rc); leaving it as-is."
-        fi
-
-        echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
-    - name: Check if release already exists
-      id: check_release
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        if gh release view "${{ steps.prep.outputs.version }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-          echo "Release ${{ steps.prep.outputs.version }} already exists; skipping."
-          echo "exists=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "Version ${CURRENT} has no release yet; will create it."
+          echo "version=${CURRENT}" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Zip integration files
-      if: steps.check_release.outputs.exists == 'false'
+      if: steps.prep.outputs.should_release == 'true'
       run: zip -r zte_router.zip custom_components/zte_router
 
     - name: Get last commit message
-      if: steps.check_release.outputs.exists == 'false'
+      if: steps.prep.outputs.should_release == 'true'
       id: last_commit
       run: |
         {
@@ -81,7 +84,7 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Create Release
-      if: steps.check_release.outputs.exists == 'false'
+      if: steps.prep.outputs.should_release == 'true'
       uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.prep.outputs.version }}


### PR DESCRIPTION
The previous auto-bump design had two bugs, both hit on the very first real run (#70 merge):

1. It pushed the bump commit directly to main, which the branch ruleset rejects ("Changes must be made through a pull request").
2. Its "skip if last commit is a bump" guard checked the top commit message, but after a PR merge the top commit is the merge commit ("Merge pull request #N..."), not the chore commit -- so it didn't recognize 1.0.55 as already-bumped and tried to bump to 1.0.56 on top of it.

Replaces the commit-message/diff heuristics with a single source of truth: check whether a GitHub release already exists for the current manifest version.
- No release yet for the current version -> nothing to bump, just create the release for it (covers manual bumps merged via PR, like 1.0.55 today).
- Release already exists and version is a plain MAJOR.MINOR.PATCH -> open a PR bumping the patch version, and try to enable auto-merge so it lands with zero manual clicks once required checks pass (falls back to a manual merge if the repo doesn't have "Allow auto-merge" turned on).
- Release already exists and version has a beta/rc suffix -> leave it alone, assume a manual beta cycle.

This also means no ruleset bypass is needed at all: the bump always goes through a real PR, respecting "require a pull request before merging" instead of working around it.