### PR TITLE
Fix deprecated ScannerEntity import path

### DIFF
--- a/custom_components/zte_router/device_tracker.py
+++ b/custom_components/zte_router/device_tracker.py
@@ -6,8 +6,7 @@ State is 'home' when the device is in the current poll's client list,
 """
 import logging
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/zte_router/manifest.json
+++ b/custom_components/zte_router/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues",
   "requirements": ["aiohttp"],
-  "version": "1.0.56b5"
+  "version": "1.0.56b6"
 }


### PR DESCRIPTION
homeassistant.components.device_tracker.config_entry.ScannerEntity is a deprecated alias, scheduled for removal in HA Core 2027.6, and logs a warning on every startup. The canonical import
(homeassistant.components.device_tracker.ScannerEntity) was already used one line above for SourceType, so this just merges the two imports.

Fixes #75