### PR TITLE
Address CodeQL alert #39 (weak password hashing) and fix real passwor…

### DIFF
--- a/custom_components/zte_router/g5_ultra_client.py
+++ b/custom_components/zte_router/g5_ultra_client.py
@@ -112,7 +112,13 @@ SUMMARY_MAP = {
 
 
 def sha256_hex(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest().upper()
+    # Not a password-storage hash -- this replicates the G5 Ultra router's own
+    # firmware-mandated login challenge-response (SHA256(SHA256(password) + salt)),
+    # which the router computes independently and compares against. The
+    # algorithm is fixed by the router, not a security choice made here;
+    # switching to a slow/salted KDF would produce a different value than the
+    # router expects and break login entirely. See CodeQL alert #39.
+    return hashlib.sha256(value.encode("utf-8")).hexdigest().upper()  # lgtm[py/weak-sensitive-data-hashing]
 
 
 # EARFCN/ARFCN -> band number fallback, used when firmware reports a carrier's

--- a/custom_components/zte_router/manifest.json
+++ b/custom_components/zte_router/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues",
   "requirements": ["aiohttp"],
-  "version": "1.0.56b6"
+  "version": "1.0.56b7"
 }

--- a/custom_components/zte_router/mc.py
+++ b/custom_components/zte_router/mc.py
@@ -148,7 +148,7 @@ class zteRouter:
         self.cookies = {}
         self.stok = None
         self.uses_stok = False
-        logger.info(f"Initializing ZTE Router with IP {ip}, Username: {username}, Password: {password}")
+        logger.info(f"Initializing ZTE Router with IP {ip}, Username: {username}")
 
         self.try_set_protocol()
         self.referer = f"{self.protocol}://{self.ip}/"
@@ -287,7 +287,15 @@ class zteRouter:
 
 
     def hash(self, str):
-        hashed = hashlib.sha256(str.encode()).hexdigest()
+        # Not a password-storage hash -- this replicates the router's own
+        # firmware-mandated login challenge-response (SHA256(password), then
+        # SHA256(that + LD-challenge)), which the router computes
+        # independently and compares against. The algorithm is fixed by the
+        # router, not a security choice made here; switching to a slow/salted
+        # KDF would produce a different value than the router expects and
+        # break login entirely. See CodeQL alert #39 (same pattern in
+        # g5_ultra_client.py's sha256_hex).
+        hashed = hashlib.sha256(str.encode()).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
         logger.debug(f"Hashed string: {hashed}")
         return hashed
 
@@ -322,7 +330,7 @@ class zteRouter:
             return ""
 
     def getCookie(self, username, password, LD, AD):
-        logger.debug(f"Getting cookie for username: {username}, password: {password}, LD: {LD}")
+        logger.debug(f"Getting cookie for username: {username}, LD: {LD}")
         header = {"Referer": self.referer}
 
         hashPassword = self.hash(password).upper()


### PR DESCRIPTION
…d logging

sha256_hex() (g5_ultra_client.py) and hash() (mc.py) both replicate a router-vendor-mandated login challenge-response
(SHA256(SHA256(password)+salt)-style), not a password-storage hash -- the router's own firmware computes and compares the same value, so the algorithm isn't a security choice made here; switching to a slow/salted KDF would break login entirely since it'd no longer match what the router expects. Documented this and added CodeQL inline suppression comments so the alert doesn't keep re-triggering for a false positive.

While reviewing this, found two real issues in the same area and fixed them:
- zteRouter.__init__ logged the plaintext router password at INFO level (always active, not gated behind debug) on every connection
- getCookie() logged the plaintext password at DEBUG level too

Both now log everything except the password itself.

manifest.json: 1.0.56b7.