### PR TITLE
Log routine polling at DEBUG instead of INFO (fixes #40)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,5 @@ jobs:
         run: python -m compileall -q custom_components/zte_router
       - name: Validate manifest.json
         run: python -c "import json; json.load(open('custom_components/zte_router/manifest.json'))"
+      - name: Run tests
+        run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/github/license/Kajkac/ZTE-MC-Home-assistant-repo)](LICENSE)
 [![Installs](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=active%20installs&suffix=%20&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.zte_router.total)](https://analytics.home-assistant.io/custom_integrations.json)
 
-[Install via HACS](#-installation) · [Supported devices](#-supported-devices) · [Beta versions](#-beta-versions) · [Services](#-services) · [Known issues](#-known-issues)
+[Install via HACS](#-installation) · [Supported devices](#-supported-devices) · [Beta versions](#-beta-versions) · [Services](#-services) · [Logging](#-logging) · [Known issues](#-known-issues)
 
 </div>
 
@@ -140,11 +140,27 @@ Advanced/debug service, **G5 Ultra only** — invokes an arbitrary ubus module/m
 
 Not needed for normal use.
 
+## 📝 Logging
+
+The integration logs through Home Assistant and writes no log files of its own, so `logger:` and the **Enable debug logging** button on the integration page control everything it emits.
+
+Routine polling is logged at `debug`; `info` is reserved for actions you triggered (sending an SMS, rebooting, toggling a switch). To go quieter still, or to trace requests for a bug report:
+
+```yaml
+logger:
+  logs:
+    custom_components.zte_router: warning  # or: debug
+```
+
+> [!NOTE]
+> Versions up to 1.0.55 wrote their own `mc.log` / `ultra.log` next to the integration, at `debug` level and with broken rotation ([#40](https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues/40)). They're no longer created, but existing files aren't removed — delete any leftovers from `config/custom_components/zte_router/`.
+
+Session tokens, auth hashes, phone numbers and SMS bodies are redacted, but `debug` still contains your router's IP and full API responses — skim before pasting into an issue.
+
 ## 🐞 Known Issues
 
 - Some sensors may briefly show `unknown` until the next refresh
 - SMS parsing can behave differently across router models/firmware
-- A few log warnings are still being cleaned up — the integration is fully usable, but not yet fully quiet in the logs
 - Found something else? [Open an issue](https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues) — reports drive what gets fixed next
 
 ## 🤝 Contributing

--- a/custom_components/zte_router/button.py
+++ b/custom_components/zte_router/button.py
@@ -3,6 +3,7 @@ import asyncio
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, MANUFACTURER, MODEL, ROUTER_TYPE_G5_ULTRA, ROUTER_TYPE_MC801
+from .log_util import describe_text, redact_phone
 from .router_backend import run_router_commands
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ class ZTERouterButton(CoordinatorEntity, ButtonEntity):
             if not self._phone_number or not self._sms_message:
                 _LOGGER.error(f"Phone number or message not set for {self._name}")
                 return
-            _LOGGER.info(f"Sending SMS to {self._phone_number} with message: {self._sms_message}")
+            _LOGGER.info(f"Sending SMS to {redact_phone(self._phone_number)} with message: {describe_text(self._sms_message)}")
 
         await self.hass.async_add_executor_job(self._execute_command)
 

--- a/custom_components/zte_router/coordinators.py
+++ b/custom_components/zte_router/coordinators.py
@@ -28,13 +28,13 @@ class ZTERouterDataUpdateCoordinator(DataUpdateCoordinator):
         self.config_entry = None
         self._data = {}
         self.allow_stale_data = allow_stale_data
-        _LOGGER.info(f"Initializing ZTERouterDataUpdateCoordinator with Ping check interval: {interval} seconds")
+        _LOGGER.debug(f"Initializing ZTERouterDataUpdateCoordinator with Ping check interval: {interval} seconds")
         super().__init__(
             hass, _LOGGER, name="zte_router", update_interval=timedelta(seconds=interval)
         )
 
     async def _async_update_data(self):
-        _LOGGER.info("Starting _async_update_data in ZTERouterDataUpdateCoordinator at %s", datetime.now())
+        _LOGGER.debug("Starting _async_update_data in ZTERouterDataUpdateCoordinator at %s", datetime.now())
         new_data = {}
         keys = {3: "dynamic_data", 7: "status_data", 16: "client_data"}
         cmds = ','.join(map(str, keys.keys()))
@@ -100,7 +100,7 @@ class ZTERouterSMSUpdateCoordinator(DataUpdateCoordinator):
         self.username_entry = username_entry if username_entry else ""
         self.router_type = router_type
         self._data = {}
-        _LOGGER.info(f"Initializing SMSUpdateCoordinator with SMS check interval: {sms_check_interval} seconds")
+        _LOGGER.debug(f"Initializing SMSUpdateCoordinator with SMS check interval: {sms_check_interval} seconds")
         super().__init__(
             hass,
             _LOGGER,
@@ -109,7 +109,7 @@ class ZTERouterSMSUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self):
-        _LOGGER.info("Starting _async_update_data in ZTERouterSMSUpdateCoordinator at %s", datetime.now())
+        _LOGGER.debug("Starting _async_update_data in ZTERouterSMSUpdateCoordinator at %s", datetime.now())
         new_data = {}
         keys = {6: "sms_data"}
         cmds = ','.join(map(str, keys.keys()))

--- a/custom_components/zte_router/g5_ultra_client.py
+++ b/custom_components/zte_router/g5_ultra_client.py
@@ -9,6 +9,8 @@ import requests
 import urllib3
 from requests.exceptions import RequestException
 
+from .log_util import redact_phone
+
 ZERO_TOKEN = "0" * 32
 
 # Uses Home Assistant's standard logging (respects the level configured via
@@ -16,7 +18,10 @@ ZERO_TOKEN = "0" * 32
 # Previously this module maintained its own separate DEBUG-forced log file
 # (ultra.log) written directly into the integration's own folder, which grew
 # to 100+ MB in normal use since it ignored HA's configured log level entirely.
-LOGGER = logging.getLogger("homeassistant.components.zte_router.g5_ultra")
+# The name must stay under `custom_components.zte_router`: that is what HA's
+# per-integration debug toggle and `logger:` YAML target for a custom
+# integration, so a `homeassistant.components.*` name escaped both.
+LOGGER = logging.getLogger(__name__)
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 CALLS = [
@@ -330,7 +335,7 @@ class G5UltraRouterRunner:
                 continue
 
             try:
-                LOGGER.info("G5 Ultra executing command %s", cmd_id)
+                LOGGER.debug("G5 Ultra executing command %s", cmd_id)
                 if cmd_id in (3, 7, 16) and gather_cache is None:
                     gather_cache = self.gather_all_data()
 
@@ -400,13 +405,13 @@ class G5UltraRouterRunner:
         if not token:
             raise RuntimeError("Unable to retrieve session token during login")
         self.session_token = token
-        LOGGER.info("Obtained new G5 Ultra session token")
+        LOGGER.debug("Obtained new G5 Ultra session token")
         return token
 
     def gather_all_data(self) -> Dict[str, Any]:
         token = self._ensure_token()
         results: Dict[str, Any] = {}
-        LOGGER.info("Starting G5 Ultra gather_all_data sequence")
+        LOGGER.debug("Starting G5 Ultra gather_all_data sequence")
         sms_capacity_flat: Dict[str, Any] = {}
         for name, module, func, params in CALLS:
             try:
@@ -448,7 +453,7 @@ class G5UltraRouterRunner:
         if flux_fields:
             results["summary"].update({k: v for k, v in flux_fields.items() if v is not None})
             results["flux_flat"] = flux_fields
-        LOGGER.info(
+        LOGGER.debug(
             "Completed gather_all_data: summary keys=%s wireless=%s lan=%s",
             list((results.get("summary") or {}).keys()),
             len(results.get("wireless_clients") or []),
@@ -1150,7 +1155,7 @@ class G5UltraRouterRunner:
         )
         result = self._safe_result(response)
         command_status = self.wait_for_sms_command(token, sms_cmd=4)
-        LOGGER.info("Sent SMS to %s with status %s", number, command_status.get("status"))
+        LOGGER.info("Sent SMS to %s with status %s", redact_phone(number), command_status.get("status"))
         return {"request": result, "command_status": command_status}
 
     def list_sms_messages(
@@ -1180,10 +1185,9 @@ class G5UltraRouterRunner:
         raw_messages = data.get("messages", []) if isinstance(data, dict) else []
         formatted = [format_sms_record(item) for item in raw_messages or []]
         LOGGER.debug(
-            "Listed SMS messages page=%s count=%s raw_preview=%s",
+            "Listed SMS messages page=%s count=%s",
             page,
             len(formatted),
-            repr(raw_messages[:1]) if raw_messages else "[]",
         )
         return {
             "page": page,

--- a/custom_components/zte_router/log_util.py
+++ b/custom_components/zte_router/log_util.py
@@ -1,0 +1,33 @@
+"""Helpers for describing sensitive values in log messages.
+
+Users routinely paste home-assistant.log into bug reports, so session tokens,
+auth hashes, phone numbers and SMS bodies must never be logged verbatim.
+"""
+
+
+def redact(value) -> str:
+    """Describe a secret (session token, auth hash) without disclosing it.
+
+    The length is kept: it distinguishes "no token" from "token of the wrong
+    shape", which is what actually helps when debugging authentication.
+    """
+    if not value:
+        return "<empty>"
+    return f"<redacted, {len(str(value))} chars>"
+
+
+def redact_phone(number) -> str:
+    """Mask a phone number, keeping the last two digits for correlation."""
+    text = str(number or "")
+    if not text:
+        return "<empty>"
+    if len(text) <= 2:
+        return "*" * len(text)
+    return "*" * (len(text) - 2) + text[-2:]
+
+
+def describe_text(text) -> str:
+    """Describe a message body by length only; SMS content is never logged."""
+    if text is None:
+        return "<empty>"
+    return f"<{len(str(text))} chars>"

--- a/custom_components/zte_router/manifest.json
+++ b/custom_components/zte_router/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues",
   "requirements": ["aiohttp", "requests"],
-  "version": "1.0.56b9"
+  "version": "1.0.56b10"
 }

--- a/custom_components/zte_router/mc.py
+++ b/custom_components/zte_router/mc.py
@@ -24,25 +24,21 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 import re
 try:
     from .pygsm7 import encodeMessage, decodeMessage
+    from .log_util import describe_text, redact, redact_phone
 except ImportError:
     # Relative import fails when mc.py is run directly as a script (e.g. by
     # the standalone Testing scripts/test_inprocess_mc.py harness), since
     # there's no enclosing package in that context.
     from pygsm7 import encodeMessage, decodeMessage
+    from log_util import describe_text, redact, redact_phone
 import traceback  # <-- add this at the top if not already
 from logging.handlers import TimedRotatingFileHandler
-import gzip
-import shutil
 
 # Disable warnings for insecure connections
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 log_certificate_details = False  # Set to True if you want to see certificate details in logs
 # Configure the logger
 logger = logging.getLogger(__name__)
-
-from logging.handlers import TimedRotatingFileHandler
-import gzip
-import shutil
 
 if __name__ == "__main__":
     # Configure logging when run directly. This runs as a standalone
@@ -78,33 +74,11 @@ if __name__ == "__main__":
         rotating_handler.setFormatter(formatter)
         rotating_handler.suffix = "%Y-%m-%d"
 
-        # Optional: Compress old logs after rotation
-        def compress_old_logs(handler):
-            log_dir = os.path.dirname(handler.baseFilename)
-            for filename in os.listdir(log_dir):
-                if filename.startswith("mc.log.") and not filename.endswith(".gz"):
-                    full_path = os.path.join(log_dir, filename)
-                    gz_path = full_path + ".gz"
-                    if not os.path.exists(gz_path):  # Only compress if not already
-                        with open(full_path, 'rb') as f_in, gzip.open(gz_path, 'wb') as f_out:
-                            shutil.copyfileobj(f_in, f_out)
-                        os.remove(full_path)
-                        logger.info(f"Compressed log file: {gz_path}")
-
-        # Hook into the handler’s rotation
-        def doRolloverAndCompress():
-            rotating_handler.doRollover()
-            compress_old_logs(rotating_handler)
-
-        # Optional override: copy on rotate + keep filename format
-        rotating_handler.rotator = lambda source, dest: shutil.copy2(source, dest)
-        rotating_handler.namer = lambda name: name
-
-        # Add the handler
+        # Rotation is left to the stdlib default. The previous `rotator`
+        # override copied the live file to the dated backup instead of
+        # renaming it, so mc.log was reopened in append mode and never
+        # truncated -- it grew without bound (#40).
         logger.addHandler(rotating_handler)
-
-        # Optional: trigger rollover + compress manually at startup
-        # doRolloverAndCompress()
 
 else:
     # Imported (in-process, e.g. from Home Assistant) -- don't force a level
@@ -153,7 +127,7 @@ class zteRouter:
         self._zte_auth_stok = stok
         self._zte_auth_AD = AD
         self._zte_auth_LD = LD
-        logger.info("Authentication credentials stored in object instance")
+        logger.debug("Authentication credentials stored in object instance")
 
     def __init__(self, ip, username, password):
         self.ip = ip
@@ -163,7 +137,7 @@ class zteRouter:
         self.cookies = {}
         self.stok = None
         self.uses_stok = False
-        logger.info(f"Initializing ZTE Router with IP {ip}, Username: {username}")
+        logger.debug(f"Initializing ZTE Router with IP {ip}, Username: {username}")
 
         self.try_set_protocol()
         self.referer = f"{self.protocol}://{self.ip}/"
@@ -193,7 +167,7 @@ class zteRouter:
         if os.path.exists(self.CERT_FILE):
             with open(self.CERT_FILE, 'r') as cert_file:
                 pem_cert = cert_file.read()
-            logger.info(f"Loaded SSL certificate from disk: {self.CERT_FILE}")
+            logger.debug(f"Loaded SSL certificate from disk: {self.CERT_FILE}")
             self.parse_certificate(pem_cert)
             return pem_cert
 
@@ -210,7 +184,7 @@ class zteRouter:
                     pem_cert = ssl.DER_cert_to_PEM_cert(der_cert)
                     with open(self.CERT_FILE, 'w') as cert_file:
                         cert_file.write(pem_cert)
-                    logger.info(f"SSL certificate for {hostname}:{port} retrieved and stored successfully")
+                    logger.debug(f"SSL certificate for {hostname}:{port} retrieved and stored successfully")
                     self.parse_certificate(pem_cert)
                     return pem_cert
         except Exception as e:
@@ -289,12 +263,12 @@ class zteRouter:
                 response = s.request('GET', url, timeout=2, retries=2)  # reduced timeout and retries
                 if response.status in [200, 302, 301]:
                     self.protocol = protocol
-                    logger.info(f"Protocol set to {protocol}")
+                    logger.debug(f"Protocol set to {protocol}")
                     if protocol == "https":
                         self.get_certificate_info(self.ip)
                     return
             except Exception as e:
-                logger.info(f"Failed to connect using {protocol}: {e}, trying next protocol.")
+                logger.debug(f"Failed to connect using {protocol}: {e}, trying next protocol.")
 
         # Instead of raising, handle router unavailability gracefully:
         logger.warning("Router is unavailable, protocol not set.")
@@ -311,7 +285,7 @@ class zteRouter:
         # break login entirely. See CodeQL alert #39 (same pattern in
         # g5_ultra_client.py's sha256_hex).
         hashed = hashlib.sha256(str.encode()).hexdigest()  # lgtm[py/weak-sensitive-data-hashing]
-        logger.debug(f"Hashed string: {hashed}")
+        logger.debug(f"Hashed string: {redact(hashed)}")
         return hashed
 
     def getVersion(self):
@@ -323,7 +297,7 @@ class zteRouter:
             r = self.request_with_session('GET', url, headers=header)
             data = r.data.decode('utf-8')
             version = json.loads(data)["wa_inner_version"]
-            logger.info(f"Router version: {version}")
+            logger.debug(f"Router version: {version}")
             return version
         except Exception as e:
             logger.error(f"Failed to fetch version: {e}")
@@ -338,14 +312,14 @@ class zteRouter:
             r = self.request_with_session('GET', url, headers=header)
             data = r.data.decode('utf-8')
             ld = json.loads(data)["LD"].upper()
-            logger.info(f"LD: {ld}")
+            logger.debug(f"LD: {redact(ld)}")
             return ld
         except Exception as e:
             logger.error(f"Failed to fetch LD: {e}")
             return ""
 
     def getCookie(self, username, password, LD, AD):
-        logger.debug(f"Getting cookie for username: {username}, LD: {LD}")
+        logger.debug(f"Getting cookie for username: {username}")
         header = {"Referer": self.referer}
 
         hashPassword = self.hash(password).upper()
@@ -385,16 +359,16 @@ class zteRouter:
             if stok:
                 self.uses_stok = True
                 self.stok = stok.value
-                logger.info(f"🔐 Router uses stok: {self.stok}")
+                logger.debug(f"🔐 Router uses stok: {redact(self.stok)}")
             else:
                 self.uses_stok = False
                 self.stok = None
-                logger.info("🔓 Router does NOT use stok (cookie-based only login)")
+                logger.debug("🔓 Router does NOT use stok (cookie-based only login)")
             # Save cookies for use in subsequent requests
             self.cookies = {}
             for key, morsel in cookie.items():
                 self.cookies[key] = morsel.value
-            logger.info(f"Obtained new session cookie: stok={self.stok}")
+            logger.debug(f"Obtained new session cookie: stok={redact(self.stok)}")
             return self.stok
         except Exception as e:
             logger.error(f"Failed to obtain cookie: {e}")
@@ -410,7 +384,7 @@ class zteRouter:
             r = self.request_with_session('POST', url, headers=header)
             data = r.data.decode('utf-8')
             rd = json.loads(data)["RD"]
-            logger.info(f"RD: {rd}")
+            logger.debug(f"RD: {redact(rd)}")
             return rd
         except Exception as e:
             logger.error(f"Failed to fetch RD: {e}")
@@ -450,7 +424,7 @@ class zteRouter:
             u = rd_json.get("RD", "")
 
             result = hash_function(a + u)
-            logger.info(f"AD: {result}")
+            logger.debug(f"AD: {redact(result)}")
             return result
         except Exception as e:
             logger.error(f"Failed to calculate AD: {e}")
@@ -459,7 +433,7 @@ class zteRouter:
 
 
     def sendsms(self, phone_number, message):
-        logger.debug(f"Sending SMS to {phone_number} with message: {message}")
+        logger.debug(f"Sending SMS to {redact_phone(phone_number)} with message: {describe_text(message)}")
         try:
             # MC888 firmware expects a fresh AD for protected write actions.
             AD = self.get_AD() or getattr(self, "_zte_auth_AD", None)
@@ -468,7 +442,7 @@ class zteRouter:
             # Encode phone number and message
             phoneNumberEncoded = urllib.parse.quote(phone_number, safe="")
             messageEncoded = encodeMessage(message)
-            logger.debug(f"Encoded SMS (GSM 7-bit): {messageEncoded}")
+            logger.debug(f"Encoded SMS (GSM 7-bit): {describe_text(messageEncoded)}")
             payload = {
                 'isTest': 'false',
                 'goformId': 'SEND_SMS',
@@ -509,7 +483,7 @@ class zteRouter:
                 red_ready = self._setup_red_crypto()
 
             if red_ready:
-                logger.info("Retrying SMS send with RED encryption payload")
+                logger.debug("Retrying SMS send with RED encryption payload")
                 AD = self.get_AD() or getattr(self, "_zte_auth_AD", None)
                 self._zte_auth_AD = AD
                 red_payload = {
@@ -540,7 +514,7 @@ class zteRouter:
                 except Exception:
                     pass
             else:
-                logger.info("RED SMS fallback unavailable in this session")
+                logger.warning("SMS send did not report success and RED fallback is unavailable")
 
             return r.status
         except Exception as e:
@@ -560,7 +534,7 @@ class zteRouter:
             cmd_url = f"{self.protocol}://{self.ip}/goform/goform_get_cmd_process?isTest=false&cmd=wa_inner_version%2Ccr_version%2Cnetwork_type%2Crssi%2Crscp%2Crmcc%2Crmnc%2Cenodeb_id%2C5g_rx0_rsrp%2C5g_rx1_rsrp%2Clte_rsrq%2Clte_rsrp%2CZ5g_snr%2CZ5g_rsrp%2CZCELLINFO_band%2CZ5g_dlEarfcn%2Clte_ca_pcell_arfcn%2Clte_ca_pcell_band%2Clte_ca_scell_band%2Clte_ca_pcell_bandwidth%2Clte_ca_scell_info%2Clte_ca_scell_bandwidth%2Cwan_lte_ca%2Clte_pci%2CZ5g_CELL_ID%2CZ5g_SINR%2Ccell_id%2Cwan_lte_ca%2Clte_ca_pcell_band%2Clte_ca_pcell_bandwidth%2Clte_ca_scell_band%2Clte_ca_scell_bandwidth%2Clte_ca_pcell_arfcn%2Clte_ca_scell_arfcn%2Clte_multi_ca_scell_info%2Cwan_active_band%2Cnr5g_pci%2Cnr5g_action_band%2Cnr5g_cell_id%2Clte_snr%2Cecio%2Cwan_active_channel%2Cnr5g_action_channel%2Cngbr_cell_info%2Cmonthly_tx_bytes%2Cmonthly_rx_bytes%2Clte_pci%2Clte_pci_lock%2Clte_earfcn_lock%2Cwan_ipaddr%2Cwan_apn%2Cpm_sensor_mdm%2Cpm_modem_5g%2Cnr5g_pci%2Cnr5g_action_channel%2Cnr5g_action_band%2CZ5g_SINR%2CZ5g_rsrp%2Cwan_active_band%2Cwan_active_channel%2Cwan_lte_ca%2Clte_multi_ca_scell_info%2Ccell_id%2Cdns_mode%2Cprefer_dns_manual%2Cstandby_dns_manual%2Cnetwork_type%2Crmcc%2Crmnc%2Clte_rsrq%2Clte_rssi%2Clte_rsrp%2Clte_snr%2Cwan_lte_ca%2Clte_ca_pcell_band%2Clte_ca_pcell_bandwidth%2Clte_ca_scell_band%2Clte_ca_scell_bandwidth%2Clte_ca_pcell_arfcn%2Clte_ca_scell_arfcn%2Cwan_ipaddr%2Cstatic_wan_ipaddr%2Copms_wan_mode%2Copms_wan_auto_mode%2Cppp_status%2Cloginfo%2Crealtime_time%2Csignalbar&multi_data=1"
             response = self.request_with_session('GET', cmd_url, headers=header)
             data = response.data.decode('utf-8')
-            logger.info("Fetched ZTE info successfully")
+            logger.debug("Fetched ZTE info successfully")
             return data
         except Exception as e:
             logger.error(f"Failed to fetch ZTE info: {e}")
@@ -578,7 +552,7 @@ class zteRouter:
             cmd_url = f"{self.protocol}://{self.ip}/goform/goform_get_cmd_process?multi_data=1&isTest=false&sms_received_flag_flag=0&sts_received_flag_flag=0&cmd=network_type%2Crssi%2Clte_rssi%2Crscp%2Clte_rsrp%2CZ5g_snr%2CZ5g_rsrp%2CZCELLINFO_band%2CZ5g_dlEarfcn%2Clte_ca_pcell_arfcn%2Clte_ca_pcell_band%2Clte_ca_scell_band%2Clte_ca_pcell_bandwidth%2Clte_ca_scell_info%2Clte_ca_scell_bandwidth%2Cwan_lte_ca%2Clte_pci%2CZ5g_CELL_ID%2CZ5g_SINR%2Ccell_id%2Cwan_lte_ca%2Clte_ca_pcell_band%2Clte_ca_pcell_bandwidth%2Clte_ca_scell_band%2Clte_ca_scell_bandwidth%2Clte_ca_pcell_arfcn%2Clte_ca_scell_arfcn%2Clte_multi_ca_scell_info%2Cwan_active_band%2Cnr5g_pci%2Cnr5g_action_band%2Cnr5g_cell_id%2Clte_snr%2Cecio%2Cwan_active_channel%2Cnr5g_action_channel%2Cmodem_main_state%2Cpin_status%2Copms_wan_mode%2Copms_wan_auto_mode%2Cloginfo%2Cnew_version_state%2Ccurrent_upgrade_state%2Cis_mandatory%2Cwifi_dfs_status%2Cbattery_value%2Cppp_dial_conn_fail_counter%2Cwifi_chip1_ssid1_auth_mode%2Cwifi_chip2_ssid1_auth_mode%2Csignalbar%2Cnetwork_type%2Cnetwork_provider%2Cppp_status%2Csimcard_roam%2Cspn_name_data%2Cspn_b1_flag%2Cspn_b2_flag%2Cwifi_onoff_state%2Cwifi_chip1_ssid1_ssid%2Cwifi_chip2_ssid1_ssid%2Cwan_lte_ca%2Cmonthly_tx_bytes%2Cmonthly_rx_bytes%2Cpppoe_status%2Cdhcp_wan_status%2Cstatic_wan_status%2Crmcc%2Crmnc%2Cmdm_mcc%2Cmdm_mnc%2CEX_SSID1%2Csta_ip_status%2CEX_wifi_profile%2Cm_ssid_enable%2CRadioOff%2Cwifi_chip1_ssid1_access_sta_num%2Cwifi_chip2_ssid1_access_sta_num%2Clan_ipaddr%2Cstation_mac%2Cwifi_access_sta_num%2Cbattery_charging%2Cbattery_vol_percent%2Cbattery_pers%2Crealtime_tx_bytes%2Crealtime_rx_bytes%2Crealtime_time%2Crealtime_tx_thrpt%2Crealtime_rx_thrpt%2Cmonthly_time%2Cdate_month%2Cdata_volume_limit_switch%2Cdata_volume_limit_size%2Cdata_volume_alert_percent%2Cdata_volume_limit_unit%2Croam_setting_option%2Cupg_roam_switch%2Cssid%2Cwifi_enable%2Cwifi_5g_enable%2Ccheck_web_conflict%2Cdial_mode%2Cprivacy_read_flag%2Cis_night_mode%2Cvpn_conn_status%2Cwan_connect_status%2Csms_received_flag%2Csts_received_flag%2Csms_unread_num%2Cwifi_chip1_ssid2_access_sta_num%2Cwifi_chip2_ssid2_access_sta_num&multi_data=1"
             response = self.request_with_session('GET', cmd_url, headers=header)
             data = response.data.decode('utf-8')
-            logger.info("Fetched ZTE info 2 successfully")
+            logger.debug("Fetched ZTE info 2 successfully")
             return data
         except Exception as e:
             logger.error(f"Failed to fetch ZTE info 2: {e}")
@@ -708,7 +682,7 @@ class zteRouter:
                     except Exception:
                         combined_data[key] = "N/A"
 
-            logger.info("✅ Fetched ZTE info using hybrid strategy")
+            logger.debug("✅ Fetched ZTE info using hybrid strategy")
             return json.dumps(combined_data)
 
         except Exception as e:
@@ -798,7 +772,7 @@ class zteRouter:
 
             # ✅ Merge all into one list
             combined_data["all_devices"] = combined_data["station_list"] + combined_data["lan_station_list"]
-            logger.info(f"Fetched and merged {len(combined_data['all_devices'])} total devices")
+            logger.debug(f"Fetched and merged {len(combined_data['all_devices'])} total devices")
 
             return json.dumps(combined_data)
 
@@ -820,7 +794,7 @@ class zteRouter:
 
             # Parse the response JSON
             data_json = json.loads(data)
-            logger.info("Fetched ZTE SMS info successfully")
+            logger.debug("Fetched ZTE SMS info successfully")
 
             # Calculate sms_capacity_left
             sms_nv_total = int(data_json.get("sms_nv_total", 0))
@@ -907,7 +881,7 @@ class zteRouter:
                 logger.warning("'messages' key is missing or invalid in SMS response; defaulting to empty list.")
                 response_json['messages'] = []
             messages = response_json['messages']
-            logger.info(f"Fetched {len(messages)} SMS messages")
+            logger.debug(f"Fetched {len(messages)} SMS messages")
             decode_errors = 0
             decrypted_any = False
 
@@ -980,7 +954,7 @@ class zteRouter:
                     'sms_class': '4'
                 }
                 response_json['messages'].append(dummy_message)
-            logger.info("Parsed all SMS messages successfully")
+            logger.debug("Parsed all SMS messages successfully")
             return json.dumps(response_json, indent=2)
         except Exception as e:
             logger.error(f"Failed to parse SMS: {e}")
@@ -1243,7 +1217,7 @@ def run_commands(ip, password, username=None, commands="", phone_number=None, me
                         result = zte.deletesms(formatted_ids)
                         results[cmd_id] = {"deleted_ids": ids, "status": result}
                     else:
-                        logger.info("No SMS in memory to delete")
+                        logger.debug("No SMS in memory to delete")
                         results[cmd_id] = {"deleted_ids": [], "status": "No SMS"}
                 else:
                     logger.warning("Failed to parse SMS for deletion")
@@ -1280,7 +1254,7 @@ def run_commands(ip, password, username=None, commands="", phone_number=None, me
                     results[cmd_id] = "SMS sending not supported in multi-command mode."
                 else:
                     if phone_number and message:
-                        logger.info(f"Sending SMS to {phone_number} with message: {message}")
+                        logger.info(f"Sending SMS to {redact_phone(phone_number)} with message: {describe_text(message)}")
                         result = zte.sendsms(phone_number, message)
                         results[cmd_id] = result
                     else:

--- a/custom_components/zte_router/sensor.py
+++ b/custom_components/zte_router/sensor.py
@@ -45,7 +45,7 @@ __all__ = [
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
-    _LOGGER.info("Setting up ZTE Router integration")
+    _LOGGER.debug("Setting up ZTE Router integration")
 
     # Hole die existierenden Coordinators aus hass.data
     coordinators = hass.data[DOMAIN][entry.entry_id]
@@ -170,7 +170,7 @@ class ZTERouterSensor(ZTERouterEntity):
         self.entity_registry_enabled_default = not disabled_by_default
         self._attr_is_diagnostics = key in DIAGNOSTICS_SENSORS
         self._attr_should_poll = False  # Disable default polling
-        _LOGGER.info(f"Initializing sensor {self._name} with key {self._key}")
+        _LOGGER.debug(f"Initializing sensor {self._name} with key {self._key}")
 
     @property
     def name(self):
@@ -213,7 +213,7 @@ class ZTERouterSensor(ZTERouterEntity):
         return None
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for sensor {self._name} at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for sensor {self._name} at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -267,7 +267,7 @@ class ZTERouterSensor(ZTERouterEntity):
                 if raw_state != old_state:
                     self._state = raw_state
                     state_changed = True
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         f"Sensor '{self._name}' updated. Old state: {old_state}, New state: {self._state} (Displayed as: {display_state})"
                     )
                 else:
@@ -279,7 +279,7 @@ class ZTERouterSensor(ZTERouterEntity):
                 if new_state != old_state:
                     self._state = new_state
                     state_changed = True
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         f"Sensor '{self._name}' updated. Old state: {old_state}, New state: {self._state}"
                     )
             else:
@@ -316,7 +316,7 @@ class LastSMSSensor(ZTERouterEntity):
 
         self.entity_registry_enabled_default = not disabled_by_default
         self._attr_should_poll = False  # Disable default polling
-        _LOGGER.info(f"Initializing Last SMS sensor with state: {self._state} (SMS ID)")
+        _LOGGER.debug(f"Initializing Last SMS sensor with state: {self._state} (SMS ID)")
 
         # Parse and format the date attribute
         if "date" in self._attributes:
@@ -361,7 +361,7 @@ class LastSMSSensor(ZTERouterEntity):
         return EntityCategory.DIAGNOSTIC
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Last SMS sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Last SMS sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -375,7 +375,7 @@ class LastSMSSensor(ZTERouterEntity):
             self._attributes["content"] = sms_data.get("content", "NO CONTENT")
             if "date" in self._attributes:
                 self._attributes["formatted_date"] = self.format_date(self._attributes["date"])
-            _LOGGER.info(f"Last SMS sensor updated. Old state: {old_state}, New state: {self._state}")
+            _LOGGER.debug(f"Last SMS sensor updated. Old state: {old_state}, New state: {self._state}")
         else:
             _LOGGER.warning("Last SMS sensor: No valid data or update failed. Setting state to Unavailable")
             self._state = "UNKNOWN"
@@ -433,7 +433,7 @@ class MonthlyUsageSensor(ZTERouterEntity):
         self._state = None
         self.entity_registry_enabled_default = True  # Set to True, enabled by default
         self._attr_should_poll = False  # Disable default polling
-        _LOGGER.info(f"Initializing Monthly Usage sensor")
+        _LOGGER.debug(f"Initializing Monthly Usage sensor")
 
     @property
     def name(self):
@@ -474,7 +474,7 @@ class MonthlyUsageSensor(ZTERouterEntity):
         return None
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Monthly Usage sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Monthly Usage sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -486,7 +486,7 @@ class MonthlyUsageSensor(ZTERouterEntity):
             monthly_rx_bytes = float(data.get("monthly_rx_bytes", 0) or 0)
             monthly_usage_gb = (monthly_tx_bytes + monthly_rx_bytes) / 1024 / 1024 / 1024
             self._state = round(monthly_usage_gb, 2)
-            _LOGGER.info(f"Monthly Usage sensor updated. Old state: {old_state}, New state: {self._state}")
+            _LOGGER.debug(f"Monthly Usage sensor updated. Old state: {old_state}, New state: {self._state}")
         else:
             _LOGGER.warning(f"Monthly Usage sensor: No valid data or update failed. Setting state to Unavailable")
             self._state = None
@@ -501,7 +501,7 @@ class monthly_tx_gb(ZTERouterEntity):
         self._state = None
         self.entity_registry_enabled_default = True  # Set to True, enabled by default
         self._attr_should_poll = False  # Disable default polling
-        _LOGGER.info(f"Initializing Monthly TX GB sensor")
+        _LOGGER.debug(f"Initializing Monthly TX GB sensor")
 
     @property
     def name(self):
@@ -542,7 +542,7 @@ class monthly_tx_gb(ZTERouterEntity):
         return None
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Monthly TX GB sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Monthly TX GB sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -553,7 +553,7 @@ class monthly_tx_gb(ZTERouterEntity):
             monthly_tx_bytes = float(data.get("monthly_tx_bytes", 0) or 0)
             monthly_tx_gb = monthly_tx_bytes / 1024 / 1024 / 1024
             self._state = round(monthly_tx_gb, 2)
-            _LOGGER.info(f"Monthly TX GB sensor updated. Old state: {old_state}, New state: {self._state}")
+            _LOGGER.debug(f"Monthly TX GB sensor updated. Old state: {old_state}, New state: {self._state}")
         else:
             _LOGGER.warning(f"Monthly TX GB sensor: No valid data or update failed. Setting state to Unavailable")
             self._state = None
@@ -568,7 +568,7 @@ class monthly_rx_gb(ZTERouterEntity):
         self._state = None
         self.entity_registry_enabled_default = True  # Set to True, enabled by default
         self._attr_should_poll = False  # Disable default polling
-        _LOGGER.info(f"Initializing Monthly RX GB sensor")
+        _LOGGER.debug(f"Initializing Monthly RX GB sensor")
 
     @property
     def name(self):
@@ -609,7 +609,7 @@ class monthly_rx_gb(ZTERouterEntity):
         return None
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Monthly RX GB sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Monthly RX GB sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -620,7 +620,7 @@ class monthly_rx_gb(ZTERouterEntity):
             monthly_rx_bytes = float(data.get("monthly_rx_bytes", 0) or 0)
             monthly_rx_gb = monthly_rx_bytes / 1024 / 1024 / 1024
             self._state = round(monthly_rx_gb, 2)
-            _LOGGER.info(f"Monthly RX GB sensor updated. Old state: {old_state}, New state: {self._state}")
+            _LOGGER.debug(f"Monthly RX GB sensor updated. Old state: {old_state}, New state: {self._state}")
         else:
             _LOGGER.warning(f"Monthly RX GB sensor: No valid data or update failed. Setting state to Unavailable")
             self._state = None
@@ -636,7 +636,7 @@ class DataLeftSensor(ZTERouterEntity):
         self.entity_registry_enabled_default = True
         self._attr_should_poll = False
         self._attr_is_diagnostics = True
-        _LOGGER.info(f"Initializing Data Left sensor")
+        _LOGGER.debug(f"Initializing Data Left sensor")
 
     @property
     def name(self):
@@ -677,7 +677,7 @@ class DataLeftSensor(ZTERouterEntity):
         return EntityCategory.DIAGNOSTIC
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Data Left sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Data Left sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -703,7 +703,7 @@ class DataLeftSensor(ZTERouterEntity):
                 data_left = 50 - (usage_gb % 50)
 
             self._state = round(data_left, 2)
-            _LOGGER.info(f"Data Left sensor updated. Old state: {old_state}, New state: {self._state} (Using FLUX: {use_flux})")
+            _LOGGER.debug(f"Data Left sensor updated. Old state: {old_state}, New state: {self._state} (Using FLUX: {use_flux})")
 
         except Exception as e:
             _LOGGER.warning(f"Failed to calculate Data Left: {e}")
@@ -725,7 +725,7 @@ class ConnectionUptimeSensor(ZTERouterEntity):
         self._state = None
         self.entity_registry_enabled_default = True  # Set to True, enabled by default
         self._attr_should_poll = False  # Disable default polling
-        _LOGGER.info(f"Initializing Connection Uptime sensor")
+        _LOGGER.debug(f"Initializing Connection Uptime sensor")
 
     @property
     def name(self):
@@ -766,7 +766,7 @@ class ConnectionUptimeSensor(ZTERouterEntity):
         return EntityCategory.DIAGNOSTIC
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Connection Uptime sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Connection Uptime sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -776,7 +776,7 @@ class ConnectionUptimeSensor(ZTERouterEntity):
             realtime_time = float(self.coordinator.data.get("realtime_time", 0) or 0)
             uptime_hours = realtime_time / 3600
             self._state = round(uptime_hours, 2)
-            _LOGGER.info(f"Connection Uptime sensor updated. Old state: {old_state}, New state: {self._state}")
+            _LOGGER.debug(f"Connection Uptime sensor updated. Old state: {old_state}, New state: {self._state}")
         else:
             _LOGGER.warning("Connection Uptime sensor: No valid data or update failed. Setting state to Unavailable")
             self._state = None
@@ -791,7 +791,7 @@ class ConnectedDevicesSensor(ZTERouterEntity):
         self._attributes = {}
         self.entity_registry_enabled_default = not disabled_by_default
         self._attr_should_poll = False
-        _LOGGER.info("Initializing Connected Devices sensor")
+        _LOGGER.debug("Initializing Connected Devices sensor")
 
     @property
     def name(self):
@@ -828,7 +828,7 @@ class ConnectedDevicesSensor(ZTERouterEntity):
         return False  # ✅ This fixes the crash
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Connected Devices sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Connected Devices sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -852,7 +852,7 @@ class ConnectedDevicesSensor(ZTERouterEntity):
             self._attributes["station_list"] = station_list
             self._attributes["lan_station_list"] = lan_station_list
             self._attributes["all_devices"] = all_devices if isinstance(all_devices, list) else (station_list + lan_station_list)
-            _LOGGER.info(f"Connected Devices updated: {total_devices} devices")
+            _LOGGER.debug(f"Connected Devices updated: {total_devices} devices")
         else:
             _LOGGER.warning("No data available for Connected Devices")
         self.async_write_ha_state()
@@ -866,7 +866,7 @@ class WiFiClientsSensor(ZTERouterEntity):
         self._attributes = {}
         self.entity_registry_enabled_default = not disabled_by_default
         self._attr_should_poll = False
-        _LOGGER.info("Initializing WiFi Clients sensor")
+        _LOGGER.debug("Initializing WiFi Clients sensor")
 
     @property
     def name(self):
@@ -945,7 +945,7 @@ class WiFiClientsSensor(ZTERouterEntity):
             self._attributes["wifi_clients"] = []
             self._attributes["fallback_count_source"] = "wifi_access_sta_num"
 
-        _LOGGER.info(f"WiFi Clients sensor updated: {self._state} devices")
+        _LOGGER.debug(f"WiFi Clients sensor updated: {self._state} devices")
         self.async_write_ha_state()
 
 
@@ -957,7 +957,7 @@ class LANClientsSensor(ZTERouterEntity):
         self._attributes = {}
         self.entity_registry_enabled_default = not disabled_by_default
         self._attr_should_poll = False
-        _LOGGER.info("Initializing LAN Clients sensor")
+        _LOGGER.debug("Initializing LAN Clients sensor")
 
     @property
     def name(self):
@@ -1016,7 +1016,7 @@ class LANClientsSensor(ZTERouterEntity):
 
         self._state = len(formatted_clients)
         self._attributes["lan_clients"] = formatted_clients
-        _LOGGER.info(f"LAN Clients sensor updated: {self._state} devices")
+        _LOGGER.debug(f"LAN Clients sensor updated: {self._state} devices")
         self.async_write_ha_state()
 
 

--- a/custom_components/zte_router/sensor_bands.py
+++ b/custom_components/zte_router/sensor_bands.py
@@ -106,7 +106,7 @@ class ConnectedBandsSensor(ZTERouterEntity):
         self.entity_registry_enabled_default = not disabled_by_default
         self._attr_is_diagnostics = True  # Ensure ConnectedBands is marked as diagnostics
         self._attr_should_poll = False  # Disable default polling
-        _LOGGER.info(f"Initializing Connected Bands sensor")
+        _LOGGER.debug(f"Initializing Connected Bands sensor")
 
     @property
     def name(self):
@@ -149,7 +149,7 @@ class ConnectedBandsSensor(ZTERouterEntity):
         return None
 
     async def async_update(self):
-        _LOGGER.info(f"Manual update requested for Connected Bands sensor at {datetime.now()}")
+        _LOGGER.debug(f"Manual update requested for Connected Bands sensor at {datetime.now()}")
         await self.coordinator.async_request_refresh()
 
     @guard_stale_data
@@ -199,7 +199,7 @@ class ConnectedBandsSensor(ZTERouterEntity):
                 "ca_bands": ca_bands_formatted or "--",
                 "enb_id": enb_id or "--",
             }
-            _LOGGER.info(f"Connected Bands sensor updated. Old state: {old_state}, New state: {self._state}")
+            _LOGGER.debug(f"Connected Bands sensor updated. Old state: {old_state}, New state: {self._state}")
         else:
             _LOGGER.warning("Connected Bands sensor: No valid data or update failed. Setting state to Unavailable")
             self._state = None

--- a/custom_components/zte_router/sensor_base.py
+++ b/custom_components/zte_router/sensor_base.py
@@ -28,7 +28,7 @@ class ZTERouterEntity(RestoreEntity, Entity):
     """Base class for ZTE Router sensors to ensure consistent MRO."""
 
     async def async_added_to_hass(self):
-        _LOGGER.info(f"Entity {self.name} added to hass at {datetime.now()}")
+        _LOGGER.debug(f"Entity {self.name} added to hass at {datetime.now()}")
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
         if last_state is not None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,101 @@
+"""Guards for the logging behaviour fixed in #40.
+
+Home Assistant logs at INFO by default and rotates only its own
+home-assistant.log, so a polling integration that logs progress at INFO -- or
+that installs a file handler of its own -- writes to disk on every cycle.
+
+Stdlib only (no Home Assistant, no router libraries) so CI can run it.
+"""
+
+import ast
+import sys
+import unittest
+from pathlib import Path
+
+INTEGRATION = Path(__file__).resolve().parent.parent / "custom_components" / "zte_router"
+sys.path.insert(0, str(INTEGRATION))
+
+from log_util import describe_text, redact, redact_phone  # noqa: E402
+
+
+def integration_modules():
+    for path in sorted(INTEGRATION.glob("*.py")):
+        yield path, ast.parse(path.read_text(encoding="utf-8"))
+
+
+def is_main_guard(test):
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+        and any(
+            isinstance(c, ast.Constant) and c.value == "__main__" for c in test.comparators
+        )
+    )
+
+
+class RedactionTest(unittest.TestCase):
+    """Values that must never reach the log verbatim."""
+
+    def test_redact_hides_the_value_but_keeps_the_length(self):
+        self.assertEqual(redact("s3cr3t-token"), "<redacted, 12 chars>")
+        self.assertNotIn("s3cr3t", redact("s3cr3t-token"))
+
+    def test_redact_reports_missing_secrets_distinctly(self):
+        # "no token at all" and "token of the wrong shape" are different bugs.
+        self.assertEqual(redact(""), "<empty>")
+        self.assertEqual(redact(None), "<empty>")
+
+    def test_redact_phone_keeps_only_the_last_two_digits(self):
+        self.assertEqual(redact_phone("+38591234567"), "**********67")
+        self.assertEqual(redact_phone("13909"), "***09")
+        self.assertEqual(redact_phone("7"), "*")
+        self.assertEqual(redact_phone(""), "<empty>")
+
+    def test_describe_text_never_reveals_the_body(self):
+        self.assertEqual(describe_text("hello world"), "<11 chars>")
+        self.assertNotIn("hello", describe_text("hello world"))
+
+
+class LoggingPolicyTest(unittest.TestCase):
+    """Static guards so the fix cannot silently regress."""
+
+    def test_module_loggers_are_named_after_their_module(self):
+        """Any other name escapes the user's `logger:` settings for this integration."""
+        offenders = []
+        for path, tree in integration_modules():
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and getattr(node.func, "attr", None) == "getLogger":
+                    for arg in node.args:
+                        if not (isinstance(arg, ast.Name) and arg.id == "__name__"):
+                            offenders.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(
+            offenders, [], "getLogger() must be called with __name__: " + ", ".join(offenders)
+        )
+
+    def test_no_log_handlers_are_installed_on_import(self):
+        """A handler attached at import writes outside HA's rotation, so it grows unbounded.
+
+        The only handlers left in the package belong to the standalone CLI.
+        """
+        offenders = []
+        for path, tree in integration_modules():
+            main_blocks = [
+                (node.lineno, node.end_lineno)
+                for node in ast.walk(tree)
+                if isinstance(node, ast.If) and is_main_guard(node.test)
+            ]
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call) and getattr(node.func, "attr", None) == "addHandler"):
+                    continue
+                if not any(start <= node.lineno <= end for start, end in main_blocks):
+                    offenders.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(
+            offenders,
+            [],
+            "addHandler() outside an `if __name__ == '__main__'` guard: " + ", ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #40.

## Problem

Home Assistant logs at INFO by default, so every INFO line a polling integration writes goes to `home-assistant.log` on **every cycle**. This one treated INFO as progress:

- `mc.py` rebuilds and re-authenticates a `zteRouter` on every poll, logging ~12 INFO lines per handshake — and both coordinators poll independently.
- `g5_ultra_client.py` logged one INFO line per ubus command, plus a summary line carrying the whole key list.
- Each of the ~200 sensors logged an INFO line per state change; RF metrics change every poll.

INFO call sites in polling paths: **80 → 0**. What's left at INFO is what the user triggered — SMS sent, reboot, switch toggled.

## Two fixes from the same pass

**The G5 logger escaped user control.** It used `getLogger("homeassistant.components.zte_router.g5_ultra")` — the *core*-integration hierarchy. HA's per-integration debug toggle and `logger:` YAML target `custom_components.zte_router` for a custom integration, so setting that to `warning` still got the full INFO stream.

**Secrets were logged verbatim** — session cookie, LD/RD/AD, password hash, phone numbers, SMS bodies — and people paste `home-assistant.log` into bug reports. New `log_util.py` describes them instead: `<redacted, 32 chars>`, `**********67`, `<11 chars>`.

## The `mc.log` rotation bug

`mc.py`'s standalone CLI handler overrode `rotator` with `shutil.copy2`, which copies the live file to the dated backup but **never truncates it** — the handler then reopens it in append mode. `backupCount` never helped. Reproduced:

```
after 3 short-lived runs, mc.log = 36870 bytes
files now: ['mc.log', 'mc.log.2026-08-22']
mc.log after 'rotation' = 36896 bytes (was 36870 before the rollover)
=> live file truncated? False
```

That's the mechanism behind the gigabyte logs reported in #40 on 1.0.55, where `mc.py` still ran as a subprocess with `DEBUG` forced. The stdlib default renames, so the override — and the compression helpers that were never wired up — are gone.

## Tests

`tests/test_logging.py`, stdlib-only (no Home Assistant, no `urllib3`/`requests`/`cryptography`) so CI runs it as one line in `lint.yml`. Guards invariants, not message text: redaction never leaks, loggers are named after their module, no handler is installed at import. Each was mutation-checked by reintroducing the bug.

## Notes

- One INFO became a **WARNING**: in `sendsms()`, reaching "RED fallback unavailable" means the plain send didn't report success and no fallback exists — the SMS most likely didn't go out. Fires per send, not per poll.
- README gains a short **Logging** section; the "not yet quiet in the logs" known issue is dropped.
- Version bumped to `1.0.56b10`. No behaviour changes outside logging.

## Possible follow-up (deliberately not in this PR)

Log calls use f-strings, so the message is interpolated whether or not it's emitted — on the polling path that cost is paid by every install that never enables debug. Switching `debug()` calls to lazy `%`-args, and trimming the oversized payload dumps (`gather_all_data`'s full key list, `str(result)[:500]`, `response.text[:1500]`), would be a worthwhile separate pass. It's an optimisation rather than a fix, so it's left out here to keep this diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)