### PR TITLE
Stop retrying the HTTPS probe a modem already refused

### DIFF
--- a/custom_components/zte_router/manifest.json
+++ b/custom_components/zte_router/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Kajkac/ZTE-MC-Home-assistant-repo/issues",
   "requirements": ["aiohttp", "requests"],
-  "version": "1.0.56b10"
+  "version": "1.0.56b11"
 }

--- a/custom_components/zte_router/mc.py
+++ b/custom_components/zte_router/mc.py
@@ -137,6 +137,7 @@ class zteRouter:
         self.cookies = {}
         self.stok = None
         self.uses_stok = False
+        self.unreachable_protocols = set()
         logger.debug(f"Initializing ZTE Router with IP {ip}, Username: {username}")
 
         self.try_set_protocol()
@@ -260,7 +261,11 @@ class zteRouter:
         for protocol in protocols:
             url = f"{protocol}://{self.ip}/index.html"
             try:
-                response = s.request('GET', url, timeout=2, retries=2)  # reduced timeout and retries
+                # A failed probe has already answered the question, and a router is
+                # rebuilt on every poll. Retrying only buys urllib3 WARNING lines,
+                # logged under its own name, which this integration's log level
+                # cannot mute.
+                response = s.request('GET', url, timeout=2, retries=False)
                 if response.status in [200, 302, 301]:
                     self.protocol = protocol
                     logger.debug(f"Protocol set to {protocol}")
@@ -269,6 +274,7 @@ class zteRouter:
                     return
             except Exception as e:
                 logger.debug(f"Failed to connect using {protocol}: {e}, trying next protocol.")
+            self.unreachable_protocols.add(protocol)
 
         # Instead of raising, handle router unavailability gracefully:
         logger.warning("Router is unavailable, protocol not set.")
@@ -982,7 +988,12 @@ class zteRouter:
                 return pem_text
 
             AD = getattr(self, "_zte_auth_AD", None)
-            base_urls = [self.referer, f"http://{self.ip}/", f"https://{self.ip}/"]
+            # Skip a scheme the probe already found unreachable: on an http-only
+            # modem the https entry costs a urllib3 retry burst every SMS poll.
+            base_urls = [self.referer] + [
+                f"{p}://{self.ip}/" for p in ("http", "https")
+                if p not in self.unreachable_protocols
+            ]
             seen = set()
 
             for base_url in base_urls:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,8 +1,9 @@
-"""Guards for the logging behaviour fixed in #40.
+"""Guards on how much this integration writes to the log.
 
 Home Assistant logs at INFO by default and rotates only its own
 home-assistant.log, so a polling integration that logs progress at INFO -- or
-that installs a file handler of its own -- writes to disk on every cycle.
+that installs a file handler of its own, or that lets a library retry a request
+it already knows will fail -- writes to disk on every cycle.
 
 Stdlib only (no Home Assistant, no router libraries) so CI can run it.
 """
@@ -21,6 +22,14 @@ from log_util import describe_text, redact, redact_phone  # noqa: E402
 def integration_modules():
     for path in sorted(INTEGRATION.glob("*.py")):
         yield path, ast.parse(path.read_text(encoding="utf-8"))
+
+
+def function_def(module, name):
+    _, tree = next(p for p in integration_modules() if p[0].name == module)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name}() not found in {module}")
 
 
 def is_main_guard(test):
@@ -95,6 +104,34 @@ class LoggingPolicyTest(unittest.TestCase):
             [],
             "addHandler() outside an `if __name__ == '__main__'` guard: " + ", ".join(offenders),
         )
+
+
+class ProtocolProbeTest(unittest.TestCase):
+    """urllib3 logs a WARNING per retry, under its own logger name, so retrying a
+    scheme the modem refuses floods home-assistant.log once per poll -- and the
+    user's log level for this integration cannot mute it."""
+
+    def test_the_scheme_probe_does_not_retry(self):
+        retries = [
+            kw.value
+            for node in ast.walk(function_def("mc.py", "try_set_protocol"))
+            if isinstance(node, ast.Call)
+            for kw in node.keywords
+            if kw.arg == "retries"
+        ]
+        self.assertTrue(retries, "the scheme probe must pass retries= explicitly")
+        for value in retries:
+            self.assertIsInstance(value, ast.Constant)
+            self.assertIs(value.value, False)
+
+    def test_red_crypto_does_not_hardcode_a_scheme(self):
+        """It must follow what the probe found, not re-probe https on an http-only modem."""
+        literals = [
+            node.value
+            for node in ast.walk(function_def("mc.py", "_setup_red_crypto"))
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        ]
+        self.assertEqual([lit for lit in literals if lit.startswith("https://")], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`zteRouter` probes `https` before `http` on every construction, and `run_commands`
builds one router per poll — so both coordinators do it independently. On a modem
whose TLS the OpenSSL in current Home Assistant won't handshake with, that probe
can never succeed. It was made with `retries=2`, and urllib3 logs a WARNING per
retry.

From a live instance, ~10 h window, `ping_interval: 30`, `sms_check_interval: 200`:

- **2736** lines from `mc.py:263` — `SSLError(... SSLV3_ALERT_HANDSHAKE_FAILURE ...)`
  against `/index.html`. 1200 ping polls + 180 SMS polls = 1380 probes × 2 warnings.
- **540** lines from `mc.py:156` — the same error against
  `goform_get_cmd_process?...cmd=web_crt_get`. 180 SMS polls × 3 warnings.

That is ~3300 WARNING lines in ten hours, a burst every ~13 s, on an install where
the integration is otherwise working fine.

**Setting the integration's log level does not help.** These records carry
urllib3's own logger name (`urllib3.connectionpool`), not
`custom_components.zte_router`, so HA's per-integration level never reaches them —
the reporting instance already had ZTE Router at `warning`. Only not making the
doomed request removes them.

## Two doomed requests

**The scheme probe.** A capability probe that fails has answered its question, so
it now passes `retries=False`. The `[200, 302, 301]` check still accepts a modem
that redirects, and the DEBUG line now shows the original `SSLError` rather than
urllib3's `MaxRetryError` wrapper.

**`_setup_red_crypto`.** It probed `https://<ip>/` unconditionally as a third base
URL, ignoring the scheme `try_set_protocol` had just settled on. `try_set_protocol`
now records the schemes it found unreachable, and the base-URL list skips them.

Requests that can genuinely succeed keep urllib3's default retries —
`request_with_session` still retries the `RemoteDisconnected` some modems throw on
`cmd=LD`.

## Why not cache, or mute

Caching the negative probe result across polls was the alternative. It needs
invalidation to recover when a firmware update turns HTTPS back on, and the one
remaining LAN-local handshake per poll isn't worth that complexity. Silencing the
urllib3 logger would also hide genuine connection problems, and leaves the wasted
handshakes in place.

## Measured

Against a fake modem that answers HTTP and refuses TLS, running the real module:

```
before: protocol='http' | urllib3 WARNINGs from 10 probes =  20 | from 1 _setup_red_crypto = 3
 after: protocol='http' | urllib3 WARNINGs from 10 probes =   0 | from 1 _setup_red_crypto = 0
```

Against a modem that does speak HTTPS, before and after are identical: same scheme
selected, same base URLs tried, in the same order.

## Tests

Two guards added to `tests/test_logging.py`, stdlib-only like the rest so CI runs
them in one line: the scheme probe must pass `retries=False`, and
`_setup_red_crypto` must not hardcode an `https://` base URL. Both were
mutation-checked by reverting the corresponding fix.

Version bumped to `1.0.56b11`. No behaviour changes outside the probe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
